### PR TITLE
cmake: improve distro integration allowing to use the standard CMake options

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -1,5 +1,16 @@
-option(USE_STATIC_POLARSSL_LIBRARY "Build PolarSSL static library." ON)
-option(USE_SHARED_POLARSSL_LIBRARY "Build PolarSSL shared library." OFF)
+# Use the standard CMake flag to drive the shared object build.
+if(DEFINED BUILD_SHARED_LIBS AND NOT DEFINED USE_STATIC_POLARSSL_LIBRARY AND NOT DEFINED USE_SHARED_POLARSSL_LIBRARY)
+  set(USE_STATIC_POLARSSL_LIBRARY ON)
+  if(BUILD_SHARED_LIBS)
+    set(USE_SHARED_POLARSSL_LIBRARY ON)
+  else()
+    set(USE_SHARED_POLARSSL_LIBRARY OFF)
+  endif()
+else()
+  option(USE_STATIC_POLARSSL_LIBRARY "Build PolarSSL static library." ON)
+  option(USE_SHARED_POLARSSL_LIBRARY "Build PolarSSL shared library." OFF)
+endif()
+
 option(LINK_WITH_PTHREAD "Explicitly link PolarSSL library to pthread." OFF)
 
 set(src


### PR DESCRIPTION
Hi all,

This patch makes polarssl more standard wrt CMake options, so makes easier its integration in distros.

Regards,

Samuel