### PR TITLE
Fix mips64 bignum implementation

### DIFF
--- a/include/polarssl/bignum.h
+++ b/include/polarssl/bignum.h
@@ -148,7 +148,7 @@ typedef uint32_t t_udbl;
           defined(__ppc64__) || defined(__powerpc64__) || \
           defined(__ia64__)  || defined(__alpha__)     || \
           (defined(__sparc__) && defined(__arch64__))  || \
-          defined(__s390x__) ) )
+          defined(__s390x__) || defined(__mips64) ) )
        #define POLARSSL_HAVE_INT64
        typedef  int64_t t_sint;
        typedef uint64_t t_uint;

--- a/include/polarssl/bn_mul.h
+++ b/include/polarssl/bn_mul.h
@@ -683,7 +683,7 @@
     );
 #endif /* Alpha */
 
-#if defined(__mips__) && !defined(__mips64__)
+#if defined(__mips__) && !defined(__mips64)
 
 #define MULADDC_INIT                    \
     asm(                                \


### PR DESCRIPTION
This pull request should fix polarssl on mips64 (which currently segfaults).

* Use correct mips64 define (```__mips64__``` has never been defined by GCC, but ```__mips64``` is).
* Added mips64 to the list of arches supporting 64-bit ints.

I was also going to add an assembly implementation of the code in ```bn_mul.h``` as well, but after doing some benchmarks it turns out GCC 4.9 produces faster code with the generic C version than my attempt at an assembly version!