### PR TITLE
aescrypt2.c local char array not initial

### DIFF
--- a/programs/aes/aescrypt2.c
+++ b/programs/aes/aescrypt2.c
@@ -112,6 +112,10 @@ int main( int argc, char *argv[] )
     }
 
     mode = atoi( argv[1] );
+    memset(IV, 0, sizeof(IV));
+    memset(key, 0, sizeof(key));
+    memset(digest, 0, sizeof(digest));
+    memset(buffer, 0, sizeof(buffer));
 
     if( mode != MODE_ENCRYPT && mode != MODE_DECRYPT )
     {


### PR DESCRIPTION
I change the main() function to a normal function, use many threads call it. the buffer[1024] is undefined everytime. it's a problem in this situation, so, in concurrent situation, these initial operation is necessary.