### PR TITLE
ssl_client2 usage prints auth_mode two times with different defaults (optional vs required)

### DIFF
--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -297,7 +297,7 @@ static int my_verify( void *data, x509_crt *crt, int depth, int *flags )
     "    nbio=%%d             default: 0 (blocking I/O)\n"  \
     "                        options: 1 (non-blocking), 2 (added delays)\n" \
     "\n"                                                    \
-    "    auth_mode=%%s        default: \"optional\"\n"      \
+    "    auth_mode=%%s        default: \"required\"\n"      \
     "                        options: none, optional, required\n" \
     USAGE_IO                                                \
     "\n"                                                    \
@@ -318,8 +318,6 @@ static int my_verify( void *data, x509_crt *crt, int depth, int *flags )
     "    max_version=%%s      default: \"\" (tls1_2)\n"     \
     "    force_version=%%s    default: \"\" (none)\n"       \
     "                        options: ssl3, tls1, tls1_1, tls1_2\n" \
-    "    auth_mode=%%s        default: \"required\"\n"      \
-    "                        options: none, optional, required\n" \
     "\n"                                                    \
     "    force_ciphersuite=<name>    default: all enabled\n"\
     " acceptable ciphersuite names:\n"


### PR DESCRIPTION
the code requires authentication - remove one of the auth_mode prints