### PR TITLE
Don't send empty supported_signature_algorithms

### DIFF
--- a/library/ssl_cli.c
+++ b/library/ssl_cli.c
@@ -158,8 +158,6 @@ static void ssl_write_signature_algorithms_ext( ssl_context *ssl,
     if( ssl->max_minor_ver != SSL_MINOR_VERSION_3 )
         return;
 
-    SSL_DEBUG_MSG( 3, ( "client hello, adding signature_algorithms extension" ) );
-
     /*
      * Prepare signature_algorithms extension (TLS 1.2)
      */
@@ -207,6 +205,11 @@ static void ssl_write_signature_algorithms_ext( ssl_context *ssl,
     sig_alg_list[sig_alg_len++] = SSL_SIG_ECDSA;
 #endif
 #endif /* POLARSSL_ECDSA_C */
+
+    if (sig_alg_len == 0)
+	return;
+
+    SSL_DEBUG_MSG( 3, ( "client hello, adding signature_algorithms extension" ) );
 
     /*
      * enum {


### PR DESCRIPTION
This came up using a polarssl client built for only ECDHE_PSK, vs a server (BouncyCastle TLS) that enforces the syntax from RFC 5246:

        SignatureAndHashAlgorithm supported_signature_algorithms<2..2^16-2>;

Note that the vector is not allowed to have zero elements.

Having said that, this probably should be raised on the TLS mailing list, and possibly an errata added to clarify this particular case (client proposes no cipher suites requiring a signature).