### PR TITLE
CVE-2015-1182: Remote attack using crafted certs

### DIFF
--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -278,6 +278,8 @@ int asn1_get_sequence_of( unsigned char **p,
             if( cur->next == NULL )
                 return( POLARSSL_ERR_ASN1_MALLOC_FAILED );
 
+            memset( cur->next, 0, sizeof( asn1_sequence ) );
+
             cur = cur->next;
         }
     }


### PR DESCRIPTION
Applied patch for [CVE-2015-1182](https://polarssl.org/tech-updates/security-advisories/polarssl-security-advisory-2014-04)