### PR TITLE
add polarssl_snprintf and polarssl_exit.  remove dependency on sscanf in library/x509.c

### DIFF
--- a/include/polarssl/check_config.h
+++ b/include/polarssl/check_config.h
@@ -192,6 +192,11 @@
 #error "POLARSSL_PKCS11_C defined, but not all prerequisites"
 #endif
 
+#if defined(POLARSSL_PLATFORM_SNPRINTF_ALT) && ( defined(_WIN32)\
+    && !defined(EFIX64) && !defined(EFI32) )
+#error "POLARSSL_PLATFORM_SNPRINTF_ALT defined but not available on Windows"
+#endif
+
 #if defined(POLARSSL_RSA_C) && ( !defined(POLARSSL_BIGNUM_C) ||         \
     !defined(POLARSSL_OID_C) )
 #error "POLARSSL_RSA_C defined, but not all prerequisites"

--- a/include/polarssl/config.h
+++ b/include/polarssl/config.h
@@ -171,6 +171,7 @@
 //#define POLARSSL_PLATFORM_SNPRINTF_ALT
 //#define POLARSSL_PLATFORM_PRINTF_ALT
 //#define POLARSSL_PLATFORM_FPRINTF_ALT
+//#define POLARSSL_PLATFORM_EXIT_ALT
 /* \} name SECTION: System support */
 
 /**
@@ -1800,7 +1801,7 @@
  * \def POLARSSL_PLATFORM_C
  *
  * Enable the platform abstraction layer that allows you to re-assign
- * functions like malloc(), free(), snprintf(), printf(), fprintf()
+ * functions like malloc(), free(), snprintf(), printf(), fprintf(), exit()
  *
  * Module:  library/platform.c
  * Caller:  Most other .c files
@@ -2148,9 +2149,10 @@
 //#define POLARSSL_PLATFORM_STD_MEM_HDR <stdlib.h> /**< Header to include if POLARSSL_PLATFORM_NO_STD_FUNCTIONS is defined. Don't define if no header is needed. */
 //#define POLARSSL_PLATFORM_STD_MALLOC   malloc /**< Default allocator to use, can be undefined */
 //#define POLARSSL_PLATFORM_STD_FREE       free /**< Default free to use, can be undefined */
-//#define POLARSSL_PLATFORM_STD_SNPRINTF 	snprintf /**< Default snprintf to use, can be undefined */
+//#define POLARSSL_PLATFORM_STD_SNPRINTF    snprintf /**< Default snprintf to use, can be undefined */
 //#define POLARSSL_PLATFORM_STD_PRINTF   printf /**< Default printf to use, can be undefined */
 //#define POLARSSL_PLATFORM_STD_FPRINTF fprintf /**< Default fprintf to use, can be undefined */
+//#define POLARSSL_PLATFORM_STD_EXIT    exit /**< Default exit to use, can be undefined */
 
 /* SSL Cache options */
 //#define SSL_CACHE_DEFAULT_TIMEOUT       86400 /**< 1 day  */

--- a/include/polarssl/config.h
+++ b/include/polarssl/config.h
@@ -162,9 +162,13 @@
  *
  * All these define require POLARSSL_PLATFORM_C to be defined!
  *
+ * WARNING: POLARSSL_PLATFORM_SNPRINTF_ALT is not available on Windows
+ * for compatibility reasons.
+ *
  * Uncomment a macro to enable alternate implementation of specific base
  * platform function
  */
+//#define POLARSSL_PLATFORM_SNPRINTF_ALT
 //#define POLARSSL_PLATFORM_PRINTF_ALT
 //#define POLARSSL_PLATFORM_FPRINTF_ALT
 /* \} name SECTION: System support */
@@ -1796,7 +1800,7 @@
  * \def POLARSSL_PLATFORM_C
  *
  * Enable the platform abstraction layer that allows you to re-assign
- * functions like malloc(), free(), printf(), fprintf()
+ * functions like malloc(), free(), snprintf(), printf(), fprintf()
  *
  * Module:  library/platform.c
  * Caller:  Most other .c files
@@ -2144,6 +2148,7 @@
 //#define POLARSSL_PLATFORM_STD_MEM_HDR <stdlib.h> /**< Header to include if POLARSSL_PLATFORM_NO_STD_FUNCTIONS is defined. Don't define if no header is needed. */
 //#define POLARSSL_PLATFORM_STD_MALLOC   malloc /**< Default allocator to use, can be undefined */
 //#define POLARSSL_PLATFORM_STD_FREE       free /**< Default free to use, can be undefined */
+//#define POLARSSL_PLATFORM_STD_SNPRINTF 	snprintf /**< Default snprintf to use, can be undefined */
 //#define POLARSSL_PLATFORM_STD_PRINTF   printf /**< Default printf to use, can be undefined */
 //#define POLARSSL_PLATFORM_STD_FPRINTF fprintf /**< Default fprintf to use, can be undefined */
 

--- a/include/polarssl/platform.h
+++ b/include/polarssl/platform.h
@@ -49,6 +49,9 @@ extern "C" {
 
 #if !defined(POLARSSL_PLATFORM_NO_STD_FUNCTIONS)
 #include <stdlib.h>
+#if !defined(POLARSSL_PLATFORM_STD_SNPRINTF)
+#define POLARSSL_PLATFORM_STD_SNPRINTF   snprintf /**< Default snprintf to use  */
+#endif
 #if !defined(POLARSSL_PLATFORM_STD_PRINTF)
 #define POLARSSL_PLATFORM_STD_PRINTF   printf /**< Default printf to use  */
 #endif
@@ -90,6 +93,25 @@ int platform_set_malloc_free( void * (*malloc_func)( size_t ),
 #define polarssl_malloc     malloc
 #define polarssl_free       free
 #endif /* POLARSSL_PLATFORM_ENTROPY */
+
+/*
+ * The function pointers for snprintf
+ */
+#if defined(POLARSSL_PLATFORM_SNPRINTF_ALT)
+extern int (*polarssl_snprintf)( char * s, size_t n, const char * format, ... );
+
+/**
+ * \brief   Set your own snprintf function pointer
+ *
+ * \param snprintf_func   the snprintf function implementation
+ *
+ * \return              0
+ */
+int platform_set_snprintf( int (*snprintf_func)( char * s, size_t n,
+                                                 const char * format, ... ) );
+#else /* POLARSSL_PLATFORM_SNPRINTF_ALT */
+#define polarssl_snprintf   snprintf
+#endif /* POLARSSL_PLATFORM_SNPRINTF_ALT */
 
 /*
  * The function pointers for printf

--- a/include/polarssl/platform.h
+++ b/include/polarssl/platform.h
@@ -64,6 +64,9 @@ extern "C" {
 #if !defined(POLARSSL_PLATFORM_STD_FREE)
 #define POLARSSL_PLATFORM_STD_FREE       free /**< Default free to use */
 #endif
+#if !defined(POLARSSL_PLATFORM_STD_EXIT)
+#define POLARSSL_PLATFORM_STD_EXIT      exit /**< Default free to use */
+#endif
 #else /* POLARSSL_PLATFORM_NO_STD_FUNCTIONS */
 #if defined(POLARSSL_PLATFORM_STD_MEM_HDR)
 #include POLARSSL_PLATFORM_STD_MEM_HDR
@@ -137,11 +140,36 @@ int platform_set_printf( int (*printf_func)( const char *, ... ) );
 #if defined(POLARSSL_PLATFORM_FPRINTF_ALT)
 extern int (*polarssl_fprintf)( FILE *stream, const char *format, ... );
 
+/**
+ * \brief   Set your own fprintf function pointer
+ *
+ * \param fprintf_func   the fprintf function implementation
+ *
+ * \return              0
+ */
 int platform_set_fprintf( int (*fprintf_func)( FILE *stream, const char *,
                                                ... ) );
 #else
 #define polarssl_fprintf    fprintf
-#endif
+#endif /* POLARSSL_PLATFORM_FPRINTF_ALT */
+
+/*
+ * The function pointers for exit
+ */
+#if defined(POLARSSL_PLATFORM_EXIT_ALT)
+extern void (*polarssl_exit)( int status );
+
+/**
+ * \brief   Set your own exit function pointer
+ *
+ * \param exit_func   the exit function implementation
+ *
+ * \return              0
+ */
+int platform_set_exit( void (*exit_func)( int status ) );
+#else
+#define polarssl_exit   exit
+#endif /* POLARSSL_PLATFORM_EXIT_ALT */
 
 #ifdef __cplusplus
 }

--- a/library/debug.c
+++ b/library/debug.c
@@ -50,6 +50,12 @@
 #endif
 #endif /* _MSC_VER */
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_snprintf snprintf
+#endif
+
 static int debug_log_mode = POLARSSL_DEBUG_DFL_MODE;
 static int debug_threshold = 0;
 
@@ -92,7 +98,7 @@ void debug_print_msg( const ssl_context *ssl, int level,
         return;
     }
 
-    snprintf( str, maxlen, "%s(%04d): %s\n", file, line, text );
+    polarssl_snprintf( str, maxlen, "%s(%04d): %s\n", file, line, text );
     str[maxlen] = '\0';
     ssl->f_dbg( ssl->p_dbg, level, str );
 }
@@ -109,9 +115,9 @@ void debug_print_ret( const ssl_context *ssl, int level,
         return;
 
     if( debug_log_mode == POLARSSL_DEBUG_LOG_FULL )
-        idx = snprintf( str, maxlen, "%s(%04d): ", file, line );
+        idx = polarssl_snprintf( str, maxlen, "%s(%04d): ", file, line );
 
-    snprintf( str + idx, maxlen - idx, "%s() returned %d (-0x%04x)\n",
+    polarssl_snprintf( str + idx, maxlen - idx, "%s() returned %d (-0x%04x)\n",
               text, ret, -ret );
 
     str[maxlen] = '\0';
@@ -129,9 +135,9 @@ void debug_print_buf( const ssl_context *ssl, int level,
         return;
 
     if( debug_log_mode == POLARSSL_DEBUG_LOG_FULL )
-        idx = snprintf( str, maxlen, "%s(%04d): ", file, line );
+        idx = polarssl_snprintf( str, maxlen, "%s(%04d): ", file, line );
 
-    snprintf( str + idx, maxlen - idx, "dumping '%s' (%u bytes)\n",
+    polarssl_snprintf( str + idx, maxlen - idx, "dumping '%s' (%u bytes)\n",
               text, (unsigned int) len );
 
     str[maxlen] = '\0';
@@ -147,26 +153,26 @@ void debug_print_buf( const ssl_context *ssl, int level,
         {
             if( i > 0 )
             {
-                snprintf( str + idx, maxlen - idx, "\n" );
+                polarssl_snprintf( str + idx, maxlen - idx, "\n" );
                 ssl->f_dbg( ssl->p_dbg, level, str );
                 idx = 0;
             }
 
             if( debug_log_mode == POLARSSL_DEBUG_LOG_FULL )
-                idx = snprintf( str, maxlen, "%s(%04d): ", file, line );
+                idx = polarssl_snprintf( str, maxlen, "%s(%04d): ", file, line );
 
-            idx += snprintf( str + idx, maxlen - idx, "%04x: ",
+            idx += polarssl_snprintf( str + idx, maxlen - idx, "%04x: ",
                              (unsigned int) i );
 
         }
 
-        idx += snprintf( str + idx, maxlen - idx, " %02x",
+        idx += polarssl_snprintf( str + idx, maxlen - idx, " %02x",
                          (unsigned int) buf[i] );
     }
 
     if( len > 0 )
     {
-        snprintf( str + idx, maxlen - idx, "\n" );
+        polarssl_snprintf( str + idx, maxlen - idx, "\n" );
         ssl->f_dbg( ssl->p_dbg, level, str );
     }
 }
@@ -182,11 +188,11 @@ void debug_print_ecp( const ssl_context *ssl, int level,
     if( ssl->f_dbg == NULL || level > debug_threshold )
         return;
 
-    snprintf( str, maxlen, "%s(X)", text );
+    polarssl_snprintf( str, maxlen, "%s(X)", text );
     str[maxlen] = '\0';
     debug_print_mpi( ssl, level, file, line, str, &X->X );
 
-    snprintf( str, maxlen, "%s(Y)", text );
+    polarssl_snprintf( str, maxlen, "%s(Y)", text );
     str[maxlen] = '\0';
     debug_print_mpi( ssl, level, file, line, str, &X->Y );
 }
@@ -213,9 +219,9 @@ void debug_print_mpi( const ssl_context *ssl, int level,
             break;
 
     if( debug_log_mode == POLARSSL_DEBUG_LOG_FULL )
-        idx = snprintf( str, maxlen, "%s(%04d): ", file, line );
+        idx = polarssl_snprintf( str, maxlen, "%s(%04d): ", file, line );
 
-    snprintf( str + idx, maxlen - idx, "value of '%s' (%d bits) is:\n",
+    polarssl_snprintf( str + idx, maxlen - idx, "value of '%s' (%d bits) is:\n",
               text, (int) ( ( n * ( sizeof(t_uint) << 3 ) ) + j + 1 ) );
 
     str[maxlen] = '\0';
@@ -238,16 +244,16 @@ void debug_print_mpi( const ssl_context *ssl, int level,
             {
                 if( j > 0 )
                 {
-                    snprintf( str + idx, maxlen - idx, "\n" );
+                    polarssl_snprintf( str + idx, maxlen - idx, "\n" );
                     ssl->f_dbg( ssl->p_dbg, level, str );
                     idx = 0;
                 }
 
                 if( debug_log_mode == POLARSSL_DEBUG_LOG_FULL )
-                    idx = snprintf( str, maxlen, "%s(%04d): ", file, line );
+                    idx = polarssl_snprintf( str, maxlen, "%s(%04d): ", file, line );
             }
 
-            idx += snprintf( str + idx, maxlen - idx, " %02x", (unsigned int)
+            idx += polarssl_snprintf( str + idx, maxlen - idx, " %02x", (unsigned int)
                              ( X->p[i - 1] >> ( k << 3 ) ) & 0xFF );
 
             j++;
@@ -259,13 +265,13 @@ void debug_print_mpi( const ssl_context *ssl, int level,
     {
         if( debug_log_mode == POLARSSL_DEBUG_LOG_FULL )
         {
-            idx = snprintf( str, maxlen, "%s(%04d): ", file, line );
+            idx = polarssl_snprintf( str, maxlen, "%s(%04d): ", file, line );
 
         }
-        idx += snprintf( str + idx, maxlen - idx, " 00" );
+        idx += polarssl_snprintf( str + idx, maxlen - idx, " 00" );
     }
 
-    snprintf( str + idx, maxlen - idx, "\n" );
+    polarssl_snprintf( str + idx, maxlen - idx, "\n" );
     ssl->f_dbg( ssl->p_dbg, level, str );
 }
 #endif /* POLARSSL_BIGNUM_C */
@@ -292,7 +298,7 @@ static void debug_print_pk( const ssl_context *ssl, int level,
         if( items[i].type == POLARSSL_PK_DEBUG_NONE )
             return;
 
-        snprintf( name, sizeof( name ), "%s%s", text, items[i].name );
+        polarssl_snprintf( name, sizeof( name ), "%s%s", text, items[i].name );
         name[sizeof( name ) - 1] = '\0';
 
         if( items[i].type == POLARSSL_PK_DEBUG_MPI )
@@ -319,7 +325,7 @@ void debug_print_crt( const ssl_context *ssl, int level,
 
     if( debug_log_mode == POLARSSL_DEBUG_LOG_FULL )
     {
-        snprintf( prefix, maxlen, "%s(%04d): ", file, line );
+        polarssl_snprintf( prefix, maxlen, "%s(%04d): ", file, line );
         prefix[maxlen] = '\0';
     }
     else
@@ -333,9 +339,9 @@ void debug_print_crt( const ssl_context *ssl, int level,
         x509_crt_info( buf, sizeof( buf ) - 1, prefix, crt );
 
         if( debug_log_mode == POLARSSL_DEBUG_LOG_FULL )
-            idx = snprintf( str, maxlen, "%s(%04d): ", file, line );
+            idx = polarssl_snprintf( str, maxlen, "%s(%04d): ", file, line );
 
-        snprintf( str + idx, maxlen - idx, "%s #%d:\n%s",
+        polarssl_snprintf( str + idx, maxlen - idx, "%s #%d:\n%s",
                   text, ++i, buf );
 
         str[maxlen] = '\0';

--- a/library/memory_buffer_alloc.c
+++ b/library/memory_buffer_alloc.c
@@ -50,6 +50,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_fprintf fprintf
+#define polarssl_exit    exit
 #endif
 
 /* Implementation that should never be optimized out by the compiler */
@@ -277,7 +278,7 @@ static void *buffer_alloc_malloc( size_t len )
         polarssl_fprintf( stderr, "FATAL: block in free_list but allocated "
                                   "data\n" );
 #endif
-        exit( 1 );
+        polarssl_exit( 1 );
     }
 
 #if defined(POLARSSL_MEMORY_DEBUG)
@@ -316,7 +317,7 @@ static void *buffer_alloc_malloc( size_t len )
 #endif
 
         if( ( heap.verify & MEMORY_VERIFY_ALLOC ) && verify_chain() != 0 )
-            exit( 1 );
+            polarssl_exit( 1 );
 
         return( ( (unsigned char *) cur ) + sizeof(memory_header) );
     }
@@ -371,7 +372,7 @@ static void *buffer_alloc_malloc( size_t len )
 #endif
 
     if( ( heap.verify & MEMORY_VERIFY_ALLOC ) && verify_chain() != 0 )
-        exit( 1 );
+        polarssl_exit( 1 );
 
     return( ( (unsigned char *) cur ) + sizeof(memory_header) );
 }
@@ -390,14 +391,14 @@ static void buffer_alloc_free( void *ptr )
         polarssl_fprintf( stderr, "FATAL: polarssl_free() outside of managed "
                                   "space\n" );
 #endif
-        exit( 1 );
+        polarssl_exit( 1 );
     }
 
     p -= sizeof(memory_header);
     hdr = (memory_header *) p;
 
     if( verify_header( hdr ) != 0 )
-        exit( 1 );
+        polarssl_exit( 1 );
 
     if( hdr->alloc != 1 )
     {
@@ -405,7 +406,7 @@ static void buffer_alloc_free( void *ptr )
         polarssl_fprintf( stderr, "FATAL: polarssl_free() on unallocated "
                                   "data\n" );
 #endif
-        exit( 1 );
+        polarssl_exit( 1 );
     }
 
     hdr->alloc = 0;
@@ -494,7 +495,7 @@ static void buffer_alloc_free( void *ptr )
 #endif
 
     if( ( heap.verify & MEMORY_VERIFY_FREE ) && verify_chain() != 0 )
-        exit( 1 );
+        polarssl_exit( 1 );
 }
 
 void memory_buffer_set_verify( int verify )

--- a/library/net.c
+++ b/library/net.c
@@ -130,6 +130,12 @@ typedef UINT32 uint32_t;
                            (((unsigned long )(n) & 0xFF000000) >> 24))
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_snprintf snprintf
+#endif
+
 unsigned short net_htons( unsigned short n );
 unsigned long  net_htonl( unsigned long  n );
 #define net_htons(n) POLARSSL_HTONS(n)
@@ -174,7 +180,7 @@ int net_connect( int *fd, const char *host, int port )
 
     /* getaddrinfo expects port as a string */
     memset( port_str, 0, sizeof( port_str ) );
-    snprintf( port_str, sizeof( port_str ), "%d", port );
+    polarssl_snprintf( port_str, sizeof( port_str ), "%d", port );
 
     /* Do name resolution with both IPv6 and IPv4, but only TCP */
     memset( &hints, 0, sizeof( hints ) );
@@ -260,7 +266,7 @@ int net_bind( int *fd, const char *bind_ip, int port )
 
     /* getaddrinfo expects port as a string */
     memset( port_str, 0, sizeof( port_str ) );
-    snprintf( port_str, sizeof( port_str ), "%d", port );
+    polarssl_snprintf( port_str, sizeof( port_str ), "%d", port );
 
     /* Bind to IPv6 and/or IPv4, but only in TCP */
     memset( &hints, 0, sizeof( hints ) );

--- a/library/oid.c
+++ b/library/oid.c
@@ -40,6 +40,12 @@
 #include "polarssl/x509.h"
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_snprintf snprintf
+#endif
+
 #include <stdio.h>
 
 /*
@@ -655,7 +661,7 @@ int oid_get_numeric_string( char *buf, size_t size,
     /* First byte contains first two dots */
     if( oid->len > 0 )
     {
-        ret = snprintf( p, n, "%d.%d", oid->p[0] / 40, oid->p[0] % 40 );
+        ret = polarssl_snprintf( p, n, "%d.%d", oid->p[0] / 40, oid->p[0] % 40 );
         SAFE_SNPRINTF();
     }
 
@@ -672,7 +678,7 @@ int oid_get_numeric_string( char *buf, size_t size,
         if( !( oid->p[i] & 0x80 ) )
         {
             /* Last byte */
-            ret = snprintf( p, n, ".%d", value );
+            ret = polarssl_snprintf( p, n, ".%d", value );
             SAFE_SNPRINTF();
             value = 0;
         }

--- a/library/platform.c
+++ b/library/platform.c
@@ -143,4 +143,27 @@ int platform_set_fprintf( int (*fprintf_func)( FILE *, const char *, ... ) )
 }
 #endif /* POLARSSL_PLATFORM_FPRINTF_ALT */
 
+#if defined(POLARSSL_PLATFORM_EXIT_ALT)
+#if !defined(POLARSSL_STD_EXIT)
+/*
+ * Make dummy function to prevent NULL pointer dereferences
+ */
+static void platform_exit_uninit( int status )
+{
+    ((void) status);
+    return( 0 );
+}
+
+#define POLARSSL_STD_EXIT   platform_exit_uninit
+#endif /* !POLARSSL_STD_EXIT */
+
+int (*polarssl_exit)( int status ) = POLARSSL_STD_EXIT;
+
+int platform_set_exit( void (*exit_func)( int status ) )
+{
+    polarssl_exit = exit_func;
+    return( 0 );
+}
+#endif /* POLARSSL_PLATFORM_EXIT_ALT */
+
 #endif /* POLARSSL_PLATFORM_C */

--- a/library/platform.c
+++ b/library/platform.c
@@ -65,6 +65,36 @@ int platform_set_malloc_free( void * (*malloc_func)( size_t ),
 }
 #endif /* POLARSSL_PLATFORM_MEMORY */
 
+#if defined(POLARSSL_PLATFORM_SNPRINTF_ALT)
+#if !defined(POLARSSL_PLATFORM_STD_SNPRINTF)
+/*
+ * Make dummy function to prevent NULL pointer dereferences
+ */
+static int platform_snprintf_uninit( char * s, size_t n,
+                                     const char * format, ... )
+{
+    ((void) s);
+    ((void) n);
+    ((void) format)
+    return( 0 );
+}
+
+#define POLARSSL_PLATFORM_STD_SNPRINTF    platform_snprintf_uninit
+#endif /* !POLARSSL_PLATFORM_STD_SNPRINTF */
+
+int (*polarssl_snprintf)( char * s, size_t n,
+                          const char * format,
+                          ... ) = POLARSSL_PLATFORM_STD_SNPRINTF;
+
+int platform_set_snprintf( int (*snprintf_func)( char * s, size_t n,
+                                                 const char * format,
+                                                 ... ) )
+{
+    polarssl_snprintf = snprintf_func;
+    return( 0 );
+}
+#endif /* POLARSSL_PLATFORM_SNPRINTF_ALT */
+
 #if defined(POLARSSL_PLATFORM_PRINTF_ALT)
 #if !defined(POLARSSL_PLATFORM_STD_PRINTF)
 /*

--- a/library/x509.c
+++ b/library/x509.c
@@ -51,6 +51,7 @@
 #if defined(POLARSSL_PLATFORM_C)
 #include "polarssl/platform.h"
 #else
+#define polarssl_snprintf   snprintf
 #define polarssl_printf     printf
 #define polarssl_malloc     malloc
 #define polarssl_free       free
@@ -787,16 +788,16 @@ int x509_dn_gets( char *buf, size_t size, const x509_name *dn )
 
         if( name != dn )
         {
-            ret = snprintf( p, n, ", " );
+            ret = polarssl_snprintf( p, n, ", " );
             SAFE_SNPRINTF();
         }
 
         ret = oid_get_attr_short_name( &name->oid, &short_name );
 
         if( ret == 0 )
-            ret = snprintf( p, n, "%s=", short_name );
+            ret = polarssl_snprintf( p, n, "%s=", short_name );
         else
-            ret = snprintf( p, n, "\?\?=" );
+            ret = polarssl_snprintf( p, n, "\?\?=" );
         SAFE_SNPRINTF();
 
         for( i = 0; i < name->val.len; i++ )
@@ -810,7 +811,7 @@ int x509_dn_gets( char *buf, size_t size, const x509_name *dn )
             else s[i] = c;
         }
         s[i] = '\0';
-        ret = snprintf( p, n, "%s", s );
+        ret = polarssl_snprintf( p, n, "%s", s );
         SAFE_SNPRINTF();
         name = name->next;
     }
@@ -839,14 +840,14 @@ int x509_serial_gets( char *buf, size_t size, const x509_buf *serial )
         if( i == 0 && nr > 1 && serial->p[i] == 0x0 )
             continue;
 
-        ret = snprintf( p, n, "%02X%s",
+        ret = polarssl_snprintf( p, n, "%02X%s",
                 serial->p[i], ( i < nr - 1 ) ? ":" : "" );
         SAFE_SNPRINTF();
     }
 
     if( nr != serial->len )
     {
-        ret = snprintf( p, n, "...." );
+        ret = polarssl_snprintf( p, n, "...." );
         SAFE_SNPRINTF();
     }
 
@@ -867,9 +868,9 @@ int x509_sig_alg_gets( char *buf, size_t size, const x509_buf *sig_oid,
 
     ret = oid_get_sig_alg_desc( sig_oid, &desc );
     if( ret != 0 )
-        ret = snprintf( p, n, "???"  );
+        ret = polarssl_snprintf( p, n, "???"  );
     else
-        ret = snprintf( p, n, "%s", desc );
+        ret = polarssl_snprintf( p, n, "%s", desc );
     SAFE_SNPRINTF();
 
 #if defined(POLARSSL_X509_RSASSA_PSS_SUPPORT)
@@ -883,7 +884,7 @@ int x509_sig_alg_gets( char *buf, size_t size, const x509_buf *sig_oid,
         md_info = md_info_from_type( md_alg );
         mgf_md_info = md_info_from_type( pss_opts->mgf1_hash_id );
 
-        ret = snprintf( p, n, " (%s, MGF1-%s, 0x%02X)",
+        ret = polarssl_snprintf( p, n, " (%s, MGF1-%s, 0x%02X)",
                               md_info ? md_info->name : "???",
                               mgf_md_info ? mgf_md_info->name : "???",
                               pss_opts->expected_salt_len );
@@ -910,7 +911,7 @@ int x509_key_size_helper( char *buf, size_t size, const char *name )
     if( strlen( name ) + sizeof( " key size" ) > size )
         return( POLARSSL_ERR_DEBUG_BUF_TOO_SMALL );
 
-    ret = snprintf( p, n, "%s key size", name );
+    ret = polarssl_snprintf( p, n, "%s key size", name );
     SAFE_SNPRINTF();
 
     return( 0 );

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -50,6 +50,7 @@
 #if defined(POLARSSL_PLATFORM_C)
 #include "polarssl/platform.h"
 #else
+#define polarssl_snprintf   snprintf
 #define polarssl_malloc     malloc
 #define polarssl_free       free
 #endif
@@ -634,23 +635,23 @@ int x509_crl_info( char *buf, size_t size, const char *prefix,
     p = buf;
     n = size;
 
-    ret = snprintf( p, n, "%sCRL version   : %d",
+    ret = polarssl_snprintf( p, n, "%sCRL version   : %d",
                                prefix, crl->version );
     SAFE_SNPRINTF();
 
-    ret = snprintf( p, n, "\n%sissuer name   : ", prefix );
+    ret = polarssl_snprintf( p, n, "\n%sissuer name   : ", prefix );
     SAFE_SNPRINTF();
     ret = x509_dn_gets( p, n, &crl->issuer );
     SAFE_SNPRINTF();
 
-    ret = snprintf( p, n, "\n%sthis update   : " \
+    ret = polarssl_snprintf( p, n, "\n%sthis update   : " \
                    "%04d-%02d-%02d %02d:%02d:%02d", prefix,
                    crl->this_update.year, crl->this_update.mon,
                    crl->this_update.day,  crl->this_update.hour,
                    crl->this_update.min,  crl->this_update.sec );
     SAFE_SNPRINTF();
 
-    ret = snprintf( p, n, "\n%snext update   : " \
+    ret = polarssl_snprintf( p, n, "\n%snext update   : " \
                    "%04d-%02d-%02d %02d:%02d:%02d", prefix,
                    crl->next_update.year, crl->next_update.mon,
                    crl->next_update.day,  crl->next_update.hour,
@@ -659,20 +660,20 @@ int x509_crl_info( char *buf, size_t size, const char *prefix,
 
     entry = &crl->entry;
 
-    ret = snprintf( p, n, "\n%sRevoked certificates:",
+    ret = polarssl_snprintf( p, n, "\n%sRevoked certificates:",
                                prefix );
     SAFE_SNPRINTF();
 
     while( entry != NULL && entry->raw.len != 0 )
     {
-        ret = snprintf( p, n, "\n%sserial number: ",
+        ret = polarssl_snprintf( p, n, "\n%sserial number: ",
                                prefix );
         SAFE_SNPRINTF();
 
         ret = x509_serial_gets( p, n, &entry->serial );
         SAFE_SNPRINTF();
 
-        ret = snprintf( p, n, " revocation date: " \
+        ret = polarssl_snprintf( p, n, " revocation date: " \
                    "%04d-%02d-%02d %02d:%02d:%02d",
                    entry->revocation_date.year, entry->revocation_date.mon,
                    entry->revocation_date.day,  entry->revocation_date.hour,
@@ -682,14 +683,14 @@ int x509_crl_info( char *buf, size_t size, const char *prefix,
         entry = entry->next;
     }
 
-    ret = snprintf( p, n, "\n%ssigned using  : ", prefix );
+    ret = polarssl_snprintf( p, n, "\n%ssigned using  : ", prefix );
     SAFE_SNPRINTF();
 
     ret = x509_sig_alg_gets( p, n, &crl->sig_oid1, crl->sig_pk, crl->sig_md,
                              crl->sig_opts );
     SAFE_SNPRINTF();
 
-    ret = snprintf( p, n, "\n" );
+    ret = polarssl_snprintf( p, n, "\n" );
     SAFE_SNPRINTF();
 
     return( (int) ( size - n ) );

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -50,6 +50,7 @@
 #if defined(POLARSSL_PLATFORM_C)
 #include "polarssl/platform.h"
 #else
+#define polarssl_snprintf   snprintf
 #define polarssl_malloc     malloc
 #define polarssl_free       free
 #endif
@@ -1033,7 +1034,7 @@ int x509_crt_parse_path( x509_crt *chain, const char *path )
 
     while( ( entry = readdir( dir ) ) != NULL )
     {
-        snprintf( entry_name, sizeof entry_name, "%s/%s", path, entry->d_name );
+        polarssl_snprintf( entry_name, sizeof entry_name, "%s/%s", path, entry->d_name );
 
         if( stat( entry_name, &sb ) == -1 )
         {
@@ -1159,7 +1160,7 @@ static int x509_info_subject_alt_name( char **buf, size_t *size,
 
 #define PRINT_ITEM(i)                           \
     {                                           \
-        ret = snprintf( p, n, "%s" i, sep );    \
+        ret = polarssl_snprintf( p, n, "%s" i, sep );    \
         SAFE_SNPRINTF();                        \
         sep = ", ";                             \
     }
@@ -1232,7 +1233,7 @@ static int x509_info_ext_key_usage( char **buf, size_t *size,
         if( oid_get_extended_key_usage( &cur->buf, &desc ) != 0 )
             desc = "???";
 
-        ret = snprintf( p, n, "%s%s", sep, desc );
+        ret = polarssl_snprintf( p, n, "%s%s", sep, desc );
         SAFE_SNPRINTF();
 
         sep = ", ";
@@ -1262,41 +1263,41 @@ int x509_crt_info( char *buf, size_t size, const char *prefix,
     p = buf;
     n = size;
 
-    ret = snprintf( p, n, "%scert. version     : %d\n",
+    ret = polarssl_snprintf( p, n, "%scert. version     : %d\n",
                                prefix, crt->version );
     SAFE_SNPRINTF();
-    ret = snprintf( p, n, "%sserial number     : ",
+    ret = polarssl_snprintf( p, n, "%sserial number     : ",
                                prefix );
     SAFE_SNPRINTF();
 
     ret = x509_serial_gets( p, n, &crt->serial );
     SAFE_SNPRINTF();
 
-    ret = snprintf( p, n, "\n%sissuer name       : ", prefix );
+    ret = polarssl_snprintf( p, n, "\n%sissuer name       : ", prefix );
     SAFE_SNPRINTF();
     ret = x509_dn_gets( p, n, &crt->issuer  );
     SAFE_SNPRINTF();
 
-    ret = snprintf( p, n, "\n%ssubject name      : ", prefix );
+    ret = polarssl_snprintf( p, n, "\n%ssubject name      : ", prefix );
     SAFE_SNPRINTF();
     ret = x509_dn_gets( p, n, &crt->subject );
     SAFE_SNPRINTF();
 
-    ret = snprintf( p, n, "\n%sissued  on        : " \
+    ret = polarssl_snprintf( p, n, "\n%sissued  on        : " \
                    "%04d-%02d-%02d %02d:%02d:%02d", prefix,
                    crt->valid_from.year, crt->valid_from.mon,
                    crt->valid_from.day,  crt->valid_from.hour,
                    crt->valid_from.min,  crt->valid_from.sec );
     SAFE_SNPRINTF();
 
-    ret = snprintf( p, n, "\n%sexpires on        : " \
+    ret = polarssl_snprintf( p, n, "\n%sexpires on        : " \
                    "%04d-%02d-%02d %02d:%02d:%02d", prefix,
                    crt->valid_to.year, crt->valid_to.mon,
                    crt->valid_to.day,  crt->valid_to.hour,
                    crt->valid_to.min,  crt->valid_to.sec );
     SAFE_SNPRINTF();
 
-    ret = snprintf( p, n, "\n%ssigned using      : ", prefix );
+    ret = polarssl_snprintf( p, n, "\n%ssigned using      : ", prefix );
     SAFE_SNPRINTF();
 
     ret = x509_sig_alg_gets( p, n, &crt->sig_oid1, crt->sig_pk,
@@ -1310,7 +1311,7 @@ int x509_crt_info( char *buf, size_t size, const char *prefix,
         return( ret );
     }
 
-    ret = snprintf( p, n, "\n%s%-" BC "s: %d bits", prefix, key_size_str,
+    ret = polarssl_snprintf( p, n, "\n%s%-" BC "s: %d bits", prefix, key_size_str,
                           (int) pk_get_size( &crt->pk ) );
     SAFE_SNPRINTF();
 
@@ -1320,20 +1321,20 @@ int x509_crt_info( char *buf, size_t size, const char *prefix,
 
     if( crt->ext_types & EXT_BASIC_CONSTRAINTS )
     {
-        ret = snprintf( p, n, "\n%sbasic constraints : CA=%s", prefix,
+        ret = polarssl_snprintf( p, n, "\n%sbasic constraints : CA=%s", prefix,
                         crt->ca_istrue ? "true" : "false" );
         SAFE_SNPRINTF();
 
         if( crt->max_pathlen > 0 )
         {
-            ret = snprintf( p, n, ", max_pathlen=%d", crt->max_pathlen - 1 );
+            ret = polarssl_snprintf( p, n, ", max_pathlen=%d", crt->max_pathlen - 1 );
             SAFE_SNPRINTF();
         }
     }
 
     if( crt->ext_types & EXT_SUBJECT_ALT_NAME )
     {
-        ret = snprintf( p, n, "\n%ssubject alt name  : ", prefix );
+        ret = polarssl_snprintf( p, n, "\n%ssubject alt name  : ", prefix );
         SAFE_SNPRINTF();
 
         if( ( ret = x509_info_subject_alt_name( &p, &n,
@@ -1343,7 +1344,7 @@ int x509_crt_info( char *buf, size_t size, const char *prefix,
 
     if( crt->ext_types & EXT_NS_CERT_TYPE )
     {
-        ret = snprintf( p, n, "\n%scert. type        : ", prefix );
+        ret = polarssl_snprintf( p, n, "\n%scert. type        : ", prefix );
         SAFE_SNPRINTF();
 
         if( ( ret = x509_info_cert_type( &p, &n, crt->ns_cert_type ) ) != 0 )
@@ -1352,7 +1353,7 @@ int x509_crt_info( char *buf, size_t size, const char *prefix,
 
     if( crt->ext_types & EXT_KEY_USAGE )
     {
-        ret = snprintf( p, n, "\n%skey usage         : ", prefix );
+        ret = polarssl_snprintf( p, n, "\n%skey usage         : ", prefix );
         SAFE_SNPRINTF();
 
         if( ( ret = x509_info_key_usage( &p, &n, crt->key_usage ) ) != 0 )
@@ -1361,7 +1362,7 @@ int x509_crt_info( char *buf, size_t size, const char *prefix,
 
     if( crt->ext_types & EXT_EXTENDED_KEY_USAGE )
     {
-        ret = snprintf( p, n, "\n%sext key usage     : ", prefix );
+        ret = polarssl_snprintf( p, n, "\n%sext key usage     : ", prefix );
         SAFE_SNPRINTF();
 
         if( ( ret = x509_info_ext_key_usage( &p, &n,
@@ -1369,7 +1370,7 @@ int x509_crt_info( char *buf, size_t size, const char *prefix,
             return( ret );
     }
 
-    ret = snprintf( p, n, "\n" );
+    ret = polarssl_snprintf( p, n, "\n" );
     SAFE_SNPRINTF();
 
     return( (int) ( size - n ) );

--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -50,6 +50,7 @@
 #if defined(POLARSSL_PLATFORM_C)
 #include "polarssl/platform.h"
 #else
+#define polarssl_snprintf   snprintf
 #define polarssl_malloc     malloc
 #define polarssl_free       free
 #endif
@@ -390,16 +391,16 @@ int x509_csr_info( char *buf, size_t size, const char *prefix,
     p = buf;
     n = size;
 
-    ret = snprintf( p, n, "%sCSR version   : %d",
+    ret = polarssl_snprintf( p, n, "%sCSR version   : %d",
                                prefix, csr->version );
     SAFE_SNPRINTF();
 
-    ret = snprintf( p, n, "\n%ssubject name  : ", prefix );
+    ret = polarssl_snprintf( p, n, "\n%ssubject name  : ", prefix );
     SAFE_SNPRINTF();
     ret = x509_dn_gets( p, n, &csr->subject );
     SAFE_SNPRINTF();
 
-    ret = snprintf( p, n, "\n%ssigned using  : ", prefix );
+    ret = polarssl_snprintf( p, n, "\n%ssigned using  : ", prefix );
     SAFE_SNPRINTF();
 
     ret = x509_sig_alg_gets( p, n, &csr->sig_oid, csr->sig_pk, csr->sig_md,
@@ -412,7 +413,7 @@ int x509_csr_info( char *buf, size_t size, const char *prefix,
         return( ret );
     }
 
-    ret = snprintf( p, n, "\n%s%-" BC "s: %d bits\n", prefix, key_size_str,
+    ret = polarssl_snprintf( p, n, "\n%s%-" BC "s: %d bits\n", prefix, key_size_str,
                           (int) pk_get_size( &csr->pk ) );
     SAFE_SNPRINTF();
 

--- a/programs/aes/aescrypt2.c
+++ b/programs/aes/aescrypt2.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #if defined(_WIN32)
 #include <windows.h>
 #if !defined(_WIN32_WCE)
@@ -61,7 +70,7 @@ int main( int argc, char *argv[] )
 {
     ((void) argc);
     ((void) argv);
-    printf("POLARSSL_AES_C and/or POLARSSL_SHA256_C not defined.\n");
+    polarssl_printf("POLARSSL_AES_C and/or POLARSSL_SHA256_C not defined.\n");
     return( 0 );
 }
 #else
@@ -101,10 +110,10 @@ int main( int argc, char *argv[] )
      */
     if( argc != 5 )
     {
-        printf( USAGE );
+        polarssl_printf( USAGE );
 
 #if defined(_WIN32)
-        printf( "\n  Press Enter to exit this program.\n" );
+        polarssl_printf( "\n  Press Enter to exit this program.\n" );
         fflush( stdout ); getchar();
 #endif
 
@@ -115,25 +124,25 @@ int main( int argc, char *argv[] )
 
     if( mode != MODE_ENCRYPT && mode != MODE_DECRYPT )
     {
-        fprintf( stderr, "invalide operation mode\n" );
+        polarssl_fprintf( stderr, "invalide operation mode\n" );
         goto exit;
     }
 
     if( strcmp( argv[2], argv[3] ) == 0 )
     {
-        fprintf( stderr, "input and output filenames must differ\n" );
+        polarssl_fprintf( stderr, "input and output filenames must differ\n" );
         goto exit;
     }
 
     if( ( fin = fopen( argv[2], "rb" ) ) == NULL )
     {
-        fprintf( stderr, "fopen(%s,rb) failed\n", argv[2] );
+        polarssl_fprintf( stderr, "fopen(%s,rb) failed\n", argv[2] );
         goto exit;
     }
 
     if( ( fout = fopen( argv[3], "wb+" ) ) == NULL )
     {
-        fprintf( stderr, "fopen(%s,wb+) failed\n", argv[3] );
+        polarssl_fprintf( stderr, "fopen(%s,wb+) failed\n", argv[3] );
         goto exit;
     }
 
@@ -186,7 +195,7 @@ int main( int argc, char *argv[] )
 
     if( li_size.LowPart == 0xFFFFFFFF && GetLastError() != NO_ERROR )
     {
-        fprintf( stderr, "SetFilePointer(0,FILE_END) failed\n" );
+        polarssl_fprintf( stderr, "SetFilePointer(0,FILE_END) failed\n" );
         goto exit;
     }
 
@@ -202,7 +211,7 @@ int main( int argc, char *argv[] )
 
     if( fseek( fin, 0, SEEK_SET ) < 0 )
     {
-        fprintf( stderr, "fseek(0,SEEK_SET) failed\n" );
+        polarssl_fprintf( stderr, "fseek(0,SEEK_SET) failed\n" );
         goto exit;
     }
 
@@ -238,7 +247,7 @@ int main( int argc, char *argv[] )
          */
         if( fwrite( IV, 1, 16, fout ) != 16 )
         {
-            fprintf( stderr, "fwrite(%d bytes) failed\n", 16 );
+            polarssl_fprintf( stderr, "fwrite(%d bytes) failed\n", 16 );
             goto exit;
         }
 
@@ -271,7 +280,7 @@ int main( int argc, char *argv[] )
 
             if( fread( buffer, 1, n, fin ) != (size_t) n )
             {
-                fprintf( stderr, "fread(%d bytes) failed\n", n );
+                polarssl_fprintf( stderr, "fread(%d bytes) failed\n", n );
                 goto exit;
             }
 
@@ -283,7 +292,7 @@ int main( int argc, char *argv[] )
 
             if( fwrite( buffer, 1, 16, fout ) != 16 )
             {
-                fprintf( stderr, "fwrite(%d bytes) failed\n", 16 );
+                polarssl_fprintf( stderr, "fwrite(%d bytes) failed\n", 16 );
                 goto exit;
             }
 
@@ -297,7 +306,7 @@ int main( int argc, char *argv[] )
 
         if( fwrite( digest, 1, 32, fout ) != 32 )
         {
-            fprintf( stderr, "fwrite(%d bytes) failed\n", 16 );
+            polarssl_fprintf( stderr, "fwrite(%d bytes) failed\n", 16 );
             goto exit;
         }
     }
@@ -317,13 +326,13 @@ int main( int argc, char *argv[] )
          */
         if( filesize < 48 )
         {
-            fprintf( stderr, "File too short to be encrypted.\n" );
+            polarssl_fprintf( stderr, "File too short to be encrypted.\n" );
             goto exit;
         }
 
         if( ( filesize & 0x0F ) != 0 )
         {
-            fprintf( stderr, "File size not a multiple of 16.\n" );
+            polarssl_fprintf( stderr, "File size not a multiple of 16.\n" );
             goto exit;
         }
 
@@ -337,7 +346,7 @@ int main( int argc, char *argv[] )
          */
         if( fread( buffer, 1, 16, fin ) != 16 )
         {
-            fprintf( stderr, "fread(%d bytes) failed\n", 16 );
+            polarssl_fprintf( stderr, "fread(%d bytes) failed\n", 16 );
             goto exit;
         }
 
@@ -370,7 +379,7 @@ int main( int argc, char *argv[] )
         {
             if( fread( buffer, 1, 16, fin ) != 16 )
             {
-                fprintf( stderr, "fread(%d bytes) failed\n", 16 );
+                polarssl_fprintf( stderr, "fread(%d bytes) failed\n", 16 );
                 goto exit;
             }
 
@@ -389,7 +398,7 @@ int main( int argc, char *argv[] )
 
             if( fwrite( buffer, 1, n, fout ) != (size_t) n )
             {
-                fprintf( stderr, "fwrite(%d bytes) failed\n", n );
+                polarssl_fprintf( stderr, "fwrite(%d bytes) failed\n", n );
                 goto exit;
             }
         }
@@ -401,7 +410,7 @@ int main( int argc, char *argv[] )
 
         if( fread( buffer, 1, 32, fin ) != 32 )
         {
-            fprintf( stderr, "fread(%d bytes) failed\n", 32 );
+            polarssl_fprintf( stderr, "fread(%d bytes) failed\n", 32 );
             goto exit;
         }
 
@@ -412,7 +421,7 @@ int main( int argc, char *argv[] )
 
         if( diff != 0 )
         {
-            fprintf( stderr, "HMAC check failed: wrong key, "
+            polarssl_fprintf( stderr, "HMAC check failed: wrong key, "
                              "or file corrupted.\n" );
             goto exit;
         }

--- a/programs/aes/crypt_and_hash.c
+++ b/programs/aes/crypt_and_hash.c
@@ -30,6 +30,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #if defined(_WIN32)
 #include <windows.h>
 #if !defined(_WIN32_WCE)
@@ -63,7 +72,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_CIPHER_C and/or POLARSSL_MD_C not defined.\n");
+    polarssl_printf("POLARSSL_CIPHER_C and/or POLARSSL_MD_C not defined.\n");
     return( 0 );
 }
 #else
@@ -105,28 +114,28 @@ int main( int argc, char *argv[] )
     {
         const int *list;
 
-        printf( USAGE );
+        polarssl_printf( USAGE );
 
-        printf( "Available ciphers:\n" );
+        polarssl_printf( "Available ciphers:\n" );
         list = cipher_list();
         while( *list )
         {
             cipher_info = cipher_info_from_type( *list );
-            printf( "  %s\n", cipher_info->name );
+            polarssl_printf( "  %s\n", cipher_info->name );
             list++;
         }
 
-        printf( "\nAvailable message digests:\n" );
+        polarssl_printf( "\nAvailable message digests:\n" );
         list = md_list();
         while( *list )
         {
             md_info = md_info_from_type( *list );
-            printf( "  %s\n", md_info->name );
+            polarssl_printf( "  %s\n", md_info->name );
             list++;
         }
 
 #if defined(_WIN32)
-        printf( "\n  Press Enter to exit this program.\n" );
+        polarssl_printf( "\n  Press Enter to exit this program.\n" );
         fflush( stdout ); getchar();
 #endif
 
@@ -137,25 +146,25 @@ int main( int argc, char *argv[] )
 
     if( mode != MODE_ENCRYPT && mode != MODE_DECRYPT )
     {
-        fprintf( stderr, "invalid operation mode\n" );
+        polarssl_fprintf( stderr, "invalid operation mode\n" );
         goto exit;
     }
 
     if( strcmp( argv[2], argv[3] ) == 0 )
     {
-        fprintf( stderr, "input and output filenames must differ\n" );
+        polarssl_fprintf( stderr, "input and output filenames must differ\n" );
         goto exit;
     }
 
     if( ( fin = fopen( argv[2], "rb" ) ) == NULL )
     {
-        fprintf( stderr, "fopen(%s,rb) failed\n", argv[2] );
+        polarssl_fprintf( stderr, "fopen(%s,rb) failed\n", argv[2] );
         goto exit;
     }
 
     if( ( fout = fopen( argv[3], "wb+" ) ) == NULL )
     {
-        fprintf( stderr, "fopen(%s,wb+) failed\n", argv[3] );
+        polarssl_fprintf( stderr, "fopen(%s,wb+) failed\n", argv[3] );
         goto exit;
     }
 
@@ -165,19 +174,19 @@ int main( int argc, char *argv[] )
     cipher_info = cipher_info_from_string( argv[4] );
     if( cipher_info == NULL )
     {
-        fprintf( stderr, "Cipher '%s' not found\n", argv[4] );
+        polarssl_fprintf( stderr, "Cipher '%s' not found\n", argv[4] );
         goto exit;
     }
     if( ( ret = cipher_init_ctx( &cipher_ctx, cipher_info) ) != 0 )
     {
-        fprintf( stderr, "cipher_init_ctx failed\n" );
+        polarssl_fprintf( stderr, "cipher_init_ctx failed\n" );
         goto exit;
     }
 
     md_info = md_info_from_string( argv[5] );
     if( md_info == NULL )
     {
-        fprintf( stderr, "Message Digest '%s' not found\n", argv[5] );
+        polarssl_fprintf( stderr, "Message Digest '%s' not found\n", argv[5] );
         goto exit;
     }
     md_init_ctx( &md_ctx, md_info);
@@ -231,7 +240,7 @@ int main( int argc, char *argv[] )
 
     if( li_size.LowPart == 0xFFFFFFFF && GetLastError() != NO_ERROR )
     {
-        fprintf( stderr, "SetFilePointer(0,FILE_END) failed\n" );
+        polarssl_fprintf( stderr, "SetFilePointer(0,FILE_END) failed\n" );
         goto exit;
     }
 
@@ -247,7 +256,7 @@ int main( int argc, char *argv[] )
 
     if( fseek( fin, 0, SEEK_SET ) < 0 )
     {
-        fprintf( stderr, "fseek(0,SEEK_SET) failed\n" );
+        polarssl_fprintf( stderr, "fseek(0,SEEK_SET) failed\n" );
         goto exit;
     }
 
@@ -283,7 +292,7 @@ int main( int argc, char *argv[] )
          */
         if( fwrite( IV, 1, 16, fout ) != 16 )
         {
-            fprintf( stderr, "fwrite(%d bytes) failed\n", 16 );
+            polarssl_fprintf( stderr, "fwrite(%d bytes) failed\n", 16 );
             goto exit;
         }
 
@@ -308,17 +317,17 @@ int main( int argc, char *argv[] )
         if( cipher_setkey( &cipher_ctx, digest, cipher_info->key_length,
                            POLARSSL_ENCRYPT ) != 0 )
         {
-            fprintf( stderr, "cipher_setkey() returned error\n");
+            polarssl_fprintf( stderr, "cipher_setkey() returned error\n");
             goto exit;
         }
         if( cipher_set_iv( &cipher_ctx, IV, 16 ) != 0 )
         {
-            fprintf( stderr, "cipher_set_iv() returned error\n");
+            polarssl_fprintf( stderr, "cipher_set_iv() returned error\n");
             goto exit;
         }
         if( cipher_reset( &cipher_ctx ) != 0 )
         {
-            fprintf( stderr, "cipher_reset() returned error\n");
+            polarssl_fprintf( stderr, "cipher_reset() returned error\n");
             goto exit;
         }
 
@@ -334,13 +343,13 @@ int main( int argc, char *argv[] )
 
             if( fread( buffer, 1, ilen, fin ) != ilen )
             {
-                fprintf( stderr, "fread(%ld bytes) failed\n", (long) ilen );
+                polarssl_fprintf( stderr, "fread(%ld bytes) failed\n", (long) ilen );
                 goto exit;
             }
 
             if( cipher_update( &cipher_ctx, buffer, ilen, output, &olen ) != 0 )
             {
-                fprintf( stderr, "cipher_update() returned error\n");
+                polarssl_fprintf( stderr, "cipher_update() returned error\n");
                 goto exit;
             }
 
@@ -348,21 +357,21 @@ int main( int argc, char *argv[] )
 
             if( fwrite( output, 1, olen, fout ) != olen )
             {
-                fprintf( stderr, "fwrite(%ld bytes) failed\n", (long) olen );
+                polarssl_fprintf( stderr, "fwrite(%ld bytes) failed\n", (long) olen );
                 goto exit;
             }
         }
 
         if( cipher_finish( &cipher_ctx, output, &olen ) != 0 )
         {
-            fprintf( stderr, "cipher_finish() returned error\n" );
+            polarssl_fprintf( stderr, "cipher_finish() returned error\n" );
             goto exit;
         }
         md_hmac_update( &md_ctx, output, olen );
 
         if( fwrite( output, 1, olen, fout ) != olen )
         {
-            fprintf( stderr, "fwrite(%ld bytes) failed\n", (long) olen );
+            polarssl_fprintf( stderr, "fwrite(%ld bytes) failed\n", (long) olen );
             goto exit;
         }
 
@@ -373,7 +382,7 @@ int main( int argc, char *argv[] )
 
         if( fwrite( digest, 1, md_get_size( md_info ), fout ) != md_get_size( md_info ) )
         {
-            fprintf( stderr, "fwrite(%d bytes) failed\n", md_get_size( md_info ) );
+            polarssl_fprintf( stderr, "fwrite(%d bytes) failed\n", md_get_size( md_info ) );
             goto exit;
         }
     }
@@ -391,14 +400,14 @@ int main( int argc, char *argv[] )
          */
         if( filesize < 16 + md_get_size( md_info ) )
         {
-            fprintf( stderr, "File too short to be encrypted.\n" );
+            polarssl_fprintf( stderr, "File too short to be encrypted.\n" );
             goto exit;
         }
 
         if( ( ( filesize - md_get_size( md_info ) ) % 
                 cipher_get_block_size( &cipher_ctx ) ) != 0 )
         {
-            fprintf( stderr, "File content not a multiple of the block size (%d).\n",
+            polarssl_fprintf( stderr, "File content not a multiple of the block size (%d).\n",
                      cipher_get_block_size( &cipher_ctx ));
             goto exit;
         }
@@ -413,7 +422,7 @@ int main( int argc, char *argv[] )
          */
         if( fread( buffer, 1, 16, fin ) != 16 )
         {
-            fprintf( stderr, "fread(%d bytes) failed\n", 16 );
+            polarssl_fprintf( stderr, "fread(%d bytes) failed\n", 16 );
             goto exit;
         }
 
@@ -440,19 +449,19 @@ int main( int argc, char *argv[] )
         if( cipher_setkey( &cipher_ctx, digest, cipher_info->key_length,
                            POLARSSL_DECRYPT ) != 0 )
         {
-            fprintf( stderr, "cipher_setkey() returned error\n" );
+            polarssl_fprintf( stderr, "cipher_setkey() returned error\n" );
             goto exit;
         }
 
         if( cipher_set_iv( &cipher_ctx, IV, 16 ) != 0 )
         {
-            fprintf( stderr, "cipher_set_iv() returned error\n" );
+            polarssl_fprintf( stderr, "cipher_set_iv() returned error\n" );
             goto exit;
         }
 
         if( cipher_reset( &cipher_ctx ) != 0 )
         {
-            fprintf( stderr, "cipher_reset() returned error\n" );
+            polarssl_fprintf( stderr, "cipher_reset() returned error\n" );
             goto exit;
         }
 
@@ -466,7 +475,7 @@ int main( int argc, char *argv[] )
             if( fread( buffer, 1, cipher_get_block_size( &cipher_ctx ), fin ) !=
                 (size_t) cipher_get_block_size( &cipher_ctx ) )
             {
-                fprintf( stderr, "fread(%d bytes) failed\n",
+                polarssl_fprintf( stderr, "fread(%d bytes) failed\n",
                     cipher_get_block_size( &cipher_ctx ) );
                 goto exit;
             }
@@ -476,13 +485,13 @@ int main( int argc, char *argv[] )
                                cipher_get_block_size( &cipher_ctx ),
                                output, &olen ) != 0 )
             {
-                fprintf( stderr, "cipher_update() returned error\n" );
+                polarssl_fprintf( stderr, "cipher_update() returned error\n" );
                 goto exit;
             }
 
             if( fwrite( output, 1, olen, fout ) != olen )
             {
-                fprintf( stderr, "fwrite(%ld bytes) failed\n", (long) olen );
+                polarssl_fprintf( stderr, "fwrite(%ld bytes) failed\n", (long) olen );
                 goto exit;
             }
         }
@@ -494,7 +503,7 @@ int main( int argc, char *argv[] )
 
         if( fread( buffer, 1, md_get_size( md_info ), fin ) != md_get_size( md_info ) )
         {
-            fprintf( stderr, "fread(%d bytes) failed\n", md_get_size( md_info ) );
+            polarssl_fprintf( stderr, "fread(%d bytes) failed\n", md_get_size( md_info ) );
             goto exit;
         }
 
@@ -505,7 +514,7 @@ int main( int argc, char *argv[] )
 
         if( diff != 0 )
         {
-            fprintf( stderr, "HMAC check failed: wrong key, "
+            polarssl_fprintf( stderr, "HMAC check failed: wrong key, "
                              "or file corrupted.\n" );
             goto exit;
         }
@@ -517,7 +526,7 @@ int main( int argc, char *argv[] )
 
         if( fwrite( output, 1, olen, fout ) != olen )
         {
-            fprintf( stderr, "fwrite(%ld bytes) failed\n", (long) olen );
+            polarssl_fprintf( stderr, "fwrite(%ld bytes) failed\n", (long) olen );
             goto exit;
         }
     }

--- a/programs/hash/generic_sum.c
+++ b/programs/hash/generic_sum.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdio.h>
 
@@ -40,7 +49,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_MD_C not defined.\n");
+    polarssl_printf("POLARSSL_MD_C not defined.\n");
     return( 0 );
 }
 #else
@@ -49,10 +58,10 @@ static int generic_wrapper( const md_info_t *md_info, char *filename, unsigned c
     int ret = md_file( md_info, filename, sum );
 
     if( ret == 1 )
-        fprintf( stderr, "failed to open: %s\n", filename );
+        polarssl_fprintf( stderr, "failed to open: %s\n", filename );
 
     if( ret == 2 )
-        fprintf( stderr, "failed to read: %s\n", filename );
+        polarssl_fprintf( stderr, "failed to read: %s\n", filename );
 
     return( ret );
 }
@@ -66,9 +75,9 @@ static int generic_print( const md_info_t *md_info, char *filename )
         return( 1 );
 
     for( i = 0; i < md_info->size; i++ )
-        printf( "%02x", sum[i] );
+        polarssl_printf( "%02x", sum[i] );
 
-    printf( "  %s\n", filename );
+    polarssl_printf( "  %s\n", filename );
     return( 0 );
 }
 
@@ -85,7 +94,7 @@ static int generic_check( const md_info_t *md_info, char *filename )
 
     if( ( f = fopen( filename, "rb" ) ) == NULL )
     {
-        printf( "failed to open: %s\n", filename );
+        polarssl_printf( "failed to open: %s\n", filename );
         return( 1 );
     }
 
@@ -102,13 +111,13 @@ static int generic_check( const md_info_t *md_info, char *filename )
 
         if( n < (size_t) 2 * md_info->size + 4 )
         {
-            printf("No '%s' hash found on line.\n", md_info->name);
+            polarssl_printf("No '%s' hash found on line.\n", md_info->name);
             continue;
         }
 
         if( line[2 * md_info->size] != ' ' || line[2 * md_info->size + 1] != ' ' )
         {
-            printf("No '%s' hash found on line.\n", md_info->name);
+            polarssl_printf("No '%s' hash found on line.\n", md_info->name);
             continue;
         }
 
@@ -136,7 +145,7 @@ static int generic_check( const md_info_t *md_info, char *filename )
         if( diff != 0 )
         {
             nb_err2++;
-            fprintf( stderr, "wrong checksum: %s\n", line + 66 );
+            polarssl_fprintf( stderr, "wrong checksum: %s\n", line + 66 );
         }
 
         n = sizeof( line );
@@ -144,13 +153,13 @@ static int generic_check( const md_info_t *md_info, char *filename )
 
     if( nb_err1 != 0 )
     {
-        printf( "WARNING: %d (out of %d) input files could "
+        polarssl_printf( "WARNING: %d (out of %d) input files could "
                 "not be read\n", nb_err1, nb_tot1 );
     }
 
     if( nb_err2 != 0 )
     {
-        printf( "WARNING: %d (out of %d) computed checksums did "
+        polarssl_printf( "WARNING: %d (out of %d) computed checksums did "
                 "not match\n", nb_err2, nb_tot2 );
     }
 
@@ -171,20 +180,20 @@ int main( int argc, char *argv[] )
     {
         const int *list;
 
-        printf( "print mode:  generic_sum <md> <file> <file> ...\n" );
-        printf( "check mode:  generic_sum <md> -c <checksum file>\n" );
+        polarssl_printf( "print mode:  generic_sum <md> <file> <file> ...\n" );
+        polarssl_printf( "check mode:  generic_sum <md> -c <checksum file>\n" );
 
-        printf( "\nAvailable message digests:\n" );
+        polarssl_printf( "\nAvailable message digests:\n" );
         list = md_list();
         while( *list )
         {
             md_info = md_info_from_type( *list );
-            printf( "  %s\n", md_info->name );
+            polarssl_printf( "  %s\n", md_info->name );
             list++;
         }
 
 #if defined(_WIN32)
-        printf( "\n  Press Enter to exit this program.\n" );
+        polarssl_printf( "\n  Press Enter to exit this program.\n" );
         fflush( stdout ); getchar();
 #endif
 
@@ -197,12 +206,12 @@ int main( int argc, char *argv[] )
     md_info = md_info_from_string( argv[1] );
     if( md_info == NULL )
     {
-        fprintf( stderr, "Message Digest '%s' not found\n", argv[1] );
+        polarssl_fprintf( stderr, "Message Digest '%s' not found\n", argv[1] );
         return( 1 );
     }
     if( md_init_ctx( &md_ctx, md_info) )
     {
-        fprintf( stderr, "Failed to initialize context.\n" );
+        polarssl_fprintf( stderr, "Failed to initialize context.\n" );
         return( 1 );
     }
 

--- a/programs/hash/hello.c
+++ b/programs/hash/hello.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <stdio.h>
 
 #include "polarssl/md5.h"
@@ -39,7 +48,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_MD5_C not defined.\n");
+    polarssl_printf("POLARSSL_MD5_C not defined.\n");
     return( 0 );
 }
 #else
@@ -52,17 +61,17 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf( "\n  MD5('%s') = ", str );
+    polarssl_printf( "\n  MD5('%s') = ", str );
 
     md5( (unsigned char *) str, 13, digest );
 
     for( i = 0; i < 16; i++ )
-        printf( "%02x", digest[i] );
+        polarssl_printf( "%02x", digest[i] );
 
-    printf( "\n\n" );
+    polarssl_printf( "\n\n" );
 
 #if defined(_WIN32)
-    printf( "  Press Enter to exit this program.\n" );
+    polarssl_printf( "  Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/hash/md5sum.c
+++ b/programs/hash/md5sum.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdio.h>
 
@@ -40,7 +49,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_MD5_C and/or POLARSSL_FS_IO not defined.\n");
+    polarssl_printf("POLARSSL_MD5_C and/or POLARSSL_FS_IO not defined.\n");
     return( 0 );
 }
 #else
@@ -49,10 +58,10 @@ static int md5_wrapper( char *filename, unsigned char *sum )
     int ret = md5_file( filename, sum );
 
     if( ret == 1 )
-        fprintf( stderr, "failed to open: %s\n", filename );
+        polarssl_fprintf( stderr, "failed to open: %s\n", filename );
 
     if( ret == 2 )
-        fprintf( stderr, "failed to read: %s\n", filename );
+        polarssl_fprintf( stderr, "failed to read: %s\n", filename );
 
     return( ret );
 }
@@ -66,9 +75,9 @@ static int md5_print( char *filename )
         return( 1 );
 
     for( i = 0; i < 16; i++ )
-        printf( "%02x", sum[i] );
+        polarssl_printf( "%02x", sum[i] );
 
-    printf( "  %s\n", filename );
+    polarssl_printf( "  %s\n", filename );
     return( 0 );
 }
 
@@ -85,7 +94,7 @@ static int md5_check( char *filename )
 
     if( ( f = fopen( filename, "rb" ) ) == NULL )
     {
-        printf( "failed to open: %s\n", filename );
+        polarssl_printf( "failed to open: %s\n", filename );
         return( 1 );
     }
 
@@ -130,7 +139,7 @@ static int md5_check( char *filename )
         if( diff != 0 )
         {
             nb_err2++;
-            fprintf( stderr, "wrong checksum: %s\n", line + 34 );
+            polarssl_fprintf( stderr, "wrong checksum: %s\n", line + 34 );
         }
 
         n = sizeof( line );
@@ -140,13 +149,13 @@ static int md5_check( char *filename )
 
     if( nb_err1 != 0 )
     {
-        printf( "WARNING: %d (out of %d) input files could "
+        polarssl_printf( "WARNING: %d (out of %d) input files could "
                 "not be read\n", nb_err1, nb_tot1 );
     }
 
     if( nb_err2 != 0 )
     {
-        printf( "WARNING: %d (out of %d) computed checksums did "
+        polarssl_printf( "WARNING: %d (out of %d) computed checksums did "
                 "not match\n", nb_err2, nb_tot2 );
     }
 
@@ -159,11 +168,11 @@ int main( int argc, char *argv[] )
 
     if( argc == 1 )
     {
-        printf( "print mode:  md5sum <file> <file> ...\n" );
-        printf( "check mode:  md5sum -c <checksum file>\n" );
+        polarssl_printf( "print mode:  md5sum <file> <file> ...\n" );
+        polarssl_printf( "check mode:  md5sum -c <checksum file>\n" );
 
 #if defined(_WIN32)
-        printf( "\n  Press Enter to exit this program.\n" );
+        polarssl_printf( "\n  Press Enter to exit this program.\n" );
         fflush( stdout ); getchar();
 #endif
 

--- a/programs/hash/sha1sum.c
+++ b/programs/hash/sha1sum.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdio.h>
 
@@ -40,7 +49,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_SHA1_C and/or POLARSSL_FS_IO not defined.\n");
+    polarssl_printf("POLARSSL_SHA1_C and/or POLARSSL_FS_IO not defined.\n");
     return( 0 );
 }
 #else
@@ -49,10 +58,10 @@ static int sha1_wrapper( char *filename, unsigned char *sum )
     int ret = sha1_file( filename, sum );
 
     if( ret == 1 )
-        fprintf( stderr, "failed to open: %s\n", filename );
+        polarssl_fprintf( stderr, "failed to open: %s\n", filename );
 
     if( ret == 2 )
-        fprintf( stderr, "failed to read: %s\n", filename );
+        polarssl_fprintf( stderr, "failed to read: %s\n", filename );
 
     return( ret );
 }
@@ -66,9 +75,9 @@ static int sha1_print( char *filename )
         return( 1 );
 
     for( i = 0; i < 20; i++ )
-        printf( "%02x", sum[i] );
+        polarssl_printf( "%02x", sum[i] );
 
-    printf( "  %s\n", filename );
+    polarssl_printf( "  %s\n", filename );
     return( 0 );
 }
 
@@ -85,7 +94,7 @@ static int sha1_check( char *filename )
 
     if( ( f = fopen( filename, "rb" ) ) == NULL )
     {
-        printf( "failed to open: %s\n", filename );
+        polarssl_printf( "failed to open: %s\n", filename );
         return( 1 );
     }
 
@@ -130,7 +139,7 @@ static int sha1_check( char *filename )
         if( diff != 0 )
         {
             nb_err2++;
-            fprintf( stderr, "wrong checksum: %s\n", line + 42 );
+            polarssl_fprintf( stderr, "wrong checksum: %s\n", line + 42 );
         }
 
         n = sizeof( line );
@@ -140,13 +149,13 @@ static int sha1_check( char *filename )
 
     if( nb_err1 != 0 )
     {
-        printf( "WARNING: %d (out of %d) input files could "
+        polarssl_printf( "WARNING: %d (out of %d) input files could "
                 "not be read\n", nb_err1, nb_tot1 );
     }
 
     if( nb_err2 != 0 )
     {
-        printf( "WARNING: %d (out of %d) computed checksums did "
+        polarssl_printf( "WARNING: %d (out of %d) computed checksums did "
                 "not match\n", nb_err2, nb_tot2 );
     }
 
@@ -159,11 +168,11 @@ int main( int argc, char *argv[] )
 
     if( argc == 1 )
     {
-        printf( "print mode:  sha1sum <file> <file> ...\n" );
-        printf( "check mode:  sha1sum -c <checksum file>\n" );
+        polarssl_printf( "print mode:  sha1sum <file> <file> ...\n" );
+        polarssl_printf( "check mode:  sha1sum -c <checksum file>\n" );
 
 #if defined(_WIN32)
-        printf( "\n  Press Enter to exit this program.\n" );
+        polarssl_printf( "\n  Press Enter to exit this program.\n" );
         fflush( stdout ); getchar();
 #endif
 

--- a/programs/hash/sha2sum.c
+++ b/programs/hash/sha2sum.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdio.h>
 
@@ -40,7 +49,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_SHA256_C and/or POLARSSL_FS_IO not defined.\n");
+    polarssl_printf("POLARSSL_SHA256_C and/or POLARSSL_FS_IO not defined.\n");
     return( 0 );
 }
 #else
@@ -49,10 +58,10 @@ static int sha256_wrapper( char *filename, unsigned char *sum )
     int ret = sha256_file( filename, sum, 0 );
 
     if( ret == 1 )
-        fprintf( stderr, "failed to open: %s\n", filename );
+        polarssl_fprintf( stderr, "failed to open: %s\n", filename );
 
     if( ret == 2 )
-        fprintf( stderr, "failed to read: %s\n", filename );
+        polarssl_fprintf( stderr, "failed to read: %s\n", filename );
 
     return( ret );
 }
@@ -66,9 +75,9 @@ static int sha256_print( char *filename )
         return( 1 );
 
     for( i = 0; i < 32; i++ )
-        printf( "%02x", sum[i] );
+        polarssl_printf( "%02x", sum[i] );
 
-    printf( "  %s\n", filename );
+    polarssl_printf( "  %s\n", filename );
     return( 0 );
 }
 
@@ -85,7 +94,7 @@ static int sha256_check( char *filename )
 
     if( ( f = fopen( filename, "rb" ) ) == NULL )
     {
-        printf( "failed to open: %s\n", filename );
+        polarssl_printf( "failed to open: %s\n", filename );
         return( 1 );
     }
 
@@ -130,7 +139,7 @@ static int sha256_check( char *filename )
         if( diff != 0 )
         {
             nb_err2++;
-            fprintf( stderr, "wrong checksum: %s\n", line + 66 );
+            polarssl_fprintf( stderr, "wrong checksum: %s\n", line + 66 );
         }
 
         n = sizeof( line );
@@ -140,13 +149,13 @@ static int sha256_check( char *filename )
 
     if( nb_err1 != 0 )
     {
-        printf( "WARNING: %d (out of %d) input files could "
+        polarssl_printf( "WARNING: %d (out of %d) input files could "
                 "not be read\n", nb_err1, nb_tot1 );
     }
 
     if( nb_err2 != 0 )
     {
-        printf( "WARNING: %d (out of %d) computed checksums did "
+        polarssl_printf( "WARNING: %d (out of %d) computed checksums did "
                 "not match\n", nb_err2, nb_tot2 );
     }
 
@@ -159,11 +168,11 @@ int main( int argc, char *argv[] )
 
     if( argc == 1 )
     {
-        printf( "print mode:  sha256sum <file> <file> ...\n" );
-        printf( "check mode:  sha256sum -c <checksum file>\n" );
+        polarssl_printf( "print mode:  sha256sum <file> <file> ...\n" );
+        polarssl_printf( "check mode:  sha256sum -c <checksum file>\n" );
 
 #if defined(_WIN32)
-        printf( "\n  Press Enter to exit this program.\n" );
+        polarssl_printf( "\n  Press Enter to exit this program.\n" );
         fflush( stdout ); getchar();
 #endif
 

--- a/programs/pkey/dh_genprime.c
+++ b/programs/pkey/dh_genprime.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <stdio.h>
 
 #include "polarssl/bignum.h"
@@ -50,7 +59,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_ENTROPY_C and/or "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_ENTROPY_C and/or "
            "POLARSSL_FS_IO and/or POLARSSL_CTR_DRBG_C and/or "
            "POLARSSL_GENPRIME not defined.\n");
     return( 0 );
@@ -73,31 +82,31 @@ int main( int argc, char *argv[] )
 
     if( ( ret = mpi_read_string( &G, 10, GENERATOR ) ) != 0 )
     {
-        printf( " failed\n  ! mpi_read_string returned %d\n", ret );
+        polarssl_printf( " failed\n  ! mpi_read_string returned %d\n", ret );
         goto exit;
     }
 
-    printf( "\nWARNING: You should not generate and use your own DHM primes\n" );
-    printf( "         unless you are very certain of what you are doing!\n" );
-    printf( "         Failing to follow this instruction may result in\n" );
-    printf( "         weak security for your connections! Use the\n" );
-    printf( "         predefined DHM parameters from dhm.h instead!\n\n" );
-    printf( "============================================================\n\n" );
+    polarssl_printf( "\nWARNING: You should not generate and use your own DHM primes\n" );
+    polarssl_printf( "         unless you are very certain of what you are doing!\n" );
+    polarssl_printf( "         Failing to follow this instruction may result in\n" );
+    polarssl_printf( "         weak security for your connections! Use the\n" );
+    polarssl_printf( "         predefined DHM parameters from dhm.h instead!\n\n" );
+    polarssl_printf( "============================================================\n\n" );
 
-    printf( "  ! Generating large primes may take minutes!\n" );
+    polarssl_printf( "  ! Generating large primes may take minutes!\n" );
 
-    printf( "\n  . Seeding the random number generator..." );
+    polarssl_printf( "\n  . Seeding the random number generator..." );
     fflush( stdout );
 
     if( ( ret = ctr_drbg_init( &ctr_drbg, entropy_func, &entropy,
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
+        polarssl_printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
         goto exit;
     }
 
-    printf( " ok\n  . Generating the modulus, please wait..." );
+    polarssl_printf( " ok\n  . Generating the modulus, please wait..." );
     fflush( stdout );
 
     /*
@@ -106,49 +115,49 @@ int main( int argc, char *argv[] )
     if( ( ret = mpi_gen_prime( &P, DH_P_SIZE, 1,
                                ctr_drbg_random, &ctr_drbg ) ) != 0 )
     {
-        printf( " failed\n  ! mpi_gen_prime returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! mpi_gen_prime returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( " ok\n  . Verifying that Q = (P-1)/2 is prime..." );
+    polarssl_printf( " ok\n  . Verifying that Q = (P-1)/2 is prime..." );
     fflush( stdout );
 
     if( ( ret = mpi_sub_int( &Q, &P, 1 ) ) != 0 )
     {
-        printf( " failed\n  ! mpi_sub_int returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! mpi_sub_int returned %d\n\n", ret );
         goto exit;
     }
 
     if( ( ret = mpi_div_int( &Q, NULL, &Q, 2 ) ) != 0 )
     {
-        printf( " failed\n  ! mpi_div_int returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! mpi_div_int returned %d\n\n", ret );
         goto exit;
     }
 
     if( ( ret = mpi_is_prime( &Q, ctr_drbg_random, &ctr_drbg ) ) != 0 )
     {
-        printf( " failed\n  ! mpi_is_prime returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! mpi_is_prime returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( " ok\n  . Exporting the value in dh_prime.txt..." );
+    polarssl_printf( " ok\n  . Exporting the value in dh_prime.txt..." );
     fflush( stdout );
 
     if( ( fout = fopen( "dh_prime.txt", "wb+" ) ) == NULL )
     {
         ret = 1;
-        printf( " failed\n  ! Could not create dh_prime.txt\n\n" );
+        polarssl_printf( " failed\n  ! Could not create dh_prime.txt\n\n" );
         goto exit;
     }
 
     if( ( ret = mpi_write_file( "P = ", &P, 16, fout ) != 0 ) ||
         ( ret = mpi_write_file( "G = ", &G, 16, fout ) != 0 ) )
     {
-        printf( " failed\n  ! mpi_write_file returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! mpi_write_file returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( " ok\n\n" );
+    polarssl_printf( " ok\n\n" );
     fclose( fout );
 
 exit:
@@ -158,7 +167,7 @@ exit:
     entropy_free( &entropy );
 
 #if defined(_WIN32)
-    printf( "  Press Enter to exit this program.\n" );
+    polarssl_printf( "  Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/pkey/dh_server.c
+++ b/programs/pkey/dh_server.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdio.h>
 
@@ -52,7 +61,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_AES_C and/or POLARSSL_DHM_C and/or POLARSSL_ENTROPY_C "
+    polarssl_printf("POLARSSL_AES_C and/or POLARSSL_DHM_C and/or POLARSSL_ENTROPY_C "
            "and/or POLARSSL_NET_C and/or POLARSSL_RSA_C and/or "
            "POLARSSL_SHA1_C and/or POLARSSL_FS_IO and/or "
            "POLARSSL_CTR_DBRG_C not defined.\n");
@@ -89,7 +98,7 @@ int main( int argc, char *argv[] )
     /*
      * 1. Setup the RNG
      */
-    printf( "\n  . Seeding the random number generator" );
+    polarssl_printf( "\n  . Seeding the random number generator" );
     fflush( stdout );
 
     entropy_init( &entropy );
@@ -97,20 +106,20 @@ int main( int argc, char *argv[] )
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
+        polarssl_printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
         goto exit;
     }
 
     /*
      * 2a. Read the server's private RSA key
      */
-    printf( "\n  . Reading private key from rsa_priv.txt" );
+    polarssl_printf( "\n  . Reading private key from rsa_priv.txt" );
     fflush( stdout );
 
     if( ( f = fopen( "rsa_priv.txt", "rb" ) ) == NULL )
     {
         ret = 1;
-        printf( " failed\n  ! Could not open rsa_priv.txt\n" \
+        polarssl_printf( " failed\n  ! Could not open rsa_priv.txt\n" \
                 "  ! Please run rsa_genkey first\n\n" );
         goto exit;
     }
@@ -126,7 +135,7 @@ int main( int argc, char *argv[] )
         ( ret = mpi_read_file( &rsa.DQ, 16, f ) ) != 0 ||
         ( ret = mpi_read_file( &rsa.QP, 16, f ) ) != 0 )
     {
-        printf( " failed\n  ! mpi_read_file returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! mpi_read_file returned %d\n\n", ret );
         goto exit;
     }
 
@@ -137,13 +146,13 @@ int main( int argc, char *argv[] )
     /*
      * 2b. Get the DHM modulus and generator
      */
-    printf( "\n  . Reading DH parameters from dh_prime.txt" );
+    polarssl_printf( "\n  . Reading DH parameters from dh_prime.txt" );
     fflush( stdout );
 
     if( ( f = fopen( "dh_prime.txt", "rb" ) ) == NULL )
     {
         ret = 1;
-        printf( " failed\n  ! Could not open dh_prime.txt\n" \
+        polarssl_printf( " failed\n  ! Could not open dh_prime.txt\n" \
                 "  ! Please run dh_genprime first\n\n" );
         goto exit;
     }
@@ -151,7 +160,7 @@ int main( int argc, char *argv[] )
     if( mpi_read_file( &dhm.P, 16, f ) != 0 ||
         mpi_read_file( &dhm.G, 16, f ) != 0 )
     {
-        printf( " failed\n  ! Invalid DH parameter file\n\n" );
+        polarssl_printf( " failed\n  ! Invalid DH parameter file\n\n" );
         goto exit;
     }
 
@@ -160,25 +169,25 @@ int main( int argc, char *argv[] )
     /*
      * 3. Wait for a client to connect
      */
-    printf( "\n  . Waiting for a remote connection" );
+    polarssl_printf( "\n  . Waiting for a remote connection" );
     fflush( stdout );
 
     if( ( ret = net_bind( &listen_fd, NULL, SERVER_PORT ) ) != 0 )
     {
-        printf( " failed\n  ! net_bind returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! net_bind returned %d\n\n", ret );
         goto exit;
     }
 
     if( ( ret = net_accept( listen_fd, &client_fd, NULL ) ) != 0 )
     {
-        printf( " failed\n  ! net_accept returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! net_accept returned %d\n\n", ret );
         goto exit;
     }
 
     /*
      * 4. Setup the DH parameters (P,G,Ys)
      */
-    printf( "\n  . Sending the server's DH parameters" );
+    polarssl_printf( "\n  . Sending the server's DH parameters" );
     fflush( stdout );
 
     memset( buf, 0, sizeof( buf ) );
@@ -186,7 +195,7 @@ int main( int argc, char *argv[] )
     if( ( ret = dhm_make_params( &dhm, (int) mpi_size( &dhm.P ), buf, &n,
                                  ctr_drbg_random, &ctr_drbg ) ) != 0 )
     {
-        printf( " failed\n  ! dhm_make_params returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! dhm_make_params returned %d\n\n", ret );
         goto exit;
     }
 
@@ -201,7 +210,7 @@ int main( int argc, char *argv[] )
     if( ( ret = rsa_pkcs1_sign( &rsa, NULL, NULL, RSA_PRIVATE, POLARSSL_MD_SHA1,
                                 0, hash, buf + n + 2 ) ) != 0 )
     {
-        printf( " failed\n  ! rsa_pkcs1_sign returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! rsa_pkcs1_sign returned %d\n\n", ret );
         goto exit;
     }
 
@@ -212,14 +221,14 @@ int main( int argc, char *argv[] )
     if( ( ret = net_send( &client_fd, buf2, 2 ) ) != 2 ||
         ( ret = net_send( &client_fd, buf, buflen ) ) != (int) buflen )
     {
-        printf( " failed\n  ! net_send returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! net_send returned %d\n\n", ret );
         goto exit;
     }
 
     /*
      * 6. Get the client's public value: Yc = G ^ Xc mod P
      */
-    printf( "\n  . Receiving the client's public value" );
+    polarssl_printf( "\n  . Receiving the client's public value" );
     fflush( stdout );
 
     memset( buf, 0, sizeof( buf ) );
@@ -227,31 +236,31 @@ int main( int argc, char *argv[] )
 
     if( ( ret = net_recv( &client_fd, buf, n ) ) != (int) n )
     {
-        printf( " failed\n  ! net_recv returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! net_recv returned %d\n\n", ret );
         goto exit;
     }
 
     if( ( ret = dhm_read_public( &dhm, buf, dhm.len ) ) != 0 )
     {
-        printf( " failed\n  ! dhm_read_public returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! dhm_read_public returned %d\n\n", ret );
         goto exit;
     }
 
     /*
      * 7. Derive the shared secret: K = Ys ^ Xc mod P
      */
-    printf( "\n  . Shared secret: " );
+    polarssl_printf( "\n  . Shared secret: " );
     fflush( stdout );
 
     if( ( ret = dhm_calc_secret( &dhm, buf, &n,
                                  ctr_drbg_random, &ctr_drbg ) ) != 0 )
     {
-        printf( " failed\n  ! dhm_calc_secret returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! dhm_calc_secret returned %d\n\n", ret );
         goto exit;
     }
 
     for( n = 0; n < 16; n++ )
-        printf( "%02x", buf[n] );
+        polarssl_printf( "%02x", buf[n] );
 
     /*
      * 8. Setup the AES-256 encryption key
@@ -261,7 +270,7 @@ int main( int argc, char *argv[] )
      * the keying material for the encryption/decryption keys
      * and MACs.
      */
-    printf( "...\n  . Encrypting and sending the ciphertext" );
+    polarssl_printf( "...\n  . Encrypting and sending the ciphertext" );
     fflush( stdout );
 
     aes_setkey_enc( &aes, buf, 256 );
@@ -270,11 +279,11 @@ int main( int argc, char *argv[] )
 
     if( ( ret = net_send( &client_fd, buf, 16 ) ) != 16 )
     {
-        printf( " failed\n  ! net_send returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! net_send returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( "\n\n" );
+    polarssl_printf( "\n\n" );
 
 exit:
 
@@ -288,7 +297,7 @@ exit:
     entropy_free( &entropy );
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/pkey/ecdsa.c
+++ b/programs/pkey/ecdsa.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include "polarssl/entropy.h"
 #include "polarssl/ctr_drbg.h"
 #include "polarssl/ecdsa.h"
@@ -57,7 +66,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_ECDSA_C and/or "
+    polarssl_printf("POLARSSL_ECDSA_C and/or "
            "POLARSSL_ENTROPY_C and/or POLARSSL_CTR_DRBG_C not defined\n");
     return( 0 );
 }
@@ -68,11 +77,11 @@ static void dump_buf( const char *title, unsigned char *buf, size_t len )
 {
     size_t i;
 
-    printf( "%s", title );
+    polarssl_printf( "%s", title );
     for( i = 0; i < len; i++ )
-        printf("%c%c", "0123456789ABCDEF" [buf[i] / 16],
+        polarssl_printf("%c%c", "0123456789ABCDEF" [buf[i] / 16],
                        "0123456789ABCDEF" [buf[i] % 16] );
-    printf( "\n" );
+    polarssl_printf( "\n" );
 }
 
 static void dump_pubkey( const char *title, ecdsa_context *key )
@@ -83,7 +92,7 @@ static void dump_pubkey( const char *title, ecdsa_context *key )
     if( ecp_point_write_binary( &key->grp, &key->Q,
                 POLARSSL_ECP_PF_UNCOMPRESSED, &len, buf, sizeof buf ) != 0 )
     {
-        printf("internal error\n");
+        polarssl_printf("internal error\n");
         return;
     }
 
@@ -114,10 +123,10 @@ int main( int argc, char *argv[] )
 
     if( argc != 1 )
     {
-        printf( "usage: ecdsa\n" );
+        polarssl_printf( "usage: ecdsa\n" );
 
 #if defined(_WIN32)
-        printf( "\n" );
+        polarssl_printf( "\n" );
 #endif
 
         goto exit;
@@ -126,7 +135,7 @@ int main( int argc, char *argv[] )
     /*
      * Generate a key pair for signing
      */
-    printf( "\n  . Seeding the random number generator..." );
+    polarssl_printf( "\n  . Seeding the random number generator..." );
     fflush( stdout );
 
     entropy_init( &entropy );
@@ -134,28 +143,28 @@ int main( int argc, char *argv[] )
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
+        polarssl_printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
         goto exit;
     }
 
-    printf( " ok\n  . Generating key pair..." );
+    polarssl_printf( " ok\n  . Generating key pair..." );
     fflush( stdout );
 
     if( ( ret = ecdsa_genkey( &ctx_sign, ECPARAMS,
                               ctr_drbg_random, &ctr_drbg ) ) != 0 )
     {
-        printf( " failed\n  ! ecdsa_genkey returned %d\n", ret );
+        polarssl_printf( " failed\n  ! ecdsa_genkey returned %d\n", ret );
         goto exit;
     }
 
-    printf( " ok (key size: %d bits)\n", (int) ctx_sign.grp.pbits );
+    polarssl_printf( " ok (key size: %d bits)\n", (int) ctx_sign.grp.pbits );
 
     dump_pubkey( "  + Public key: ", &ctx_sign );
 
     /*
      * Sign some message hash
      */
-    printf( "  . Signing message..." );
+    polarssl_printf( "  . Signing message..." );
     fflush( stdout );
 
     if( ( ret = ecdsa_write_signature( &ctx_sign,
@@ -163,10 +172,10 @@ int main( int argc, char *argv[] )
                                        sig, &sig_len,
                                        ctr_drbg_random, &ctr_drbg ) ) != 0 )
     {
-        printf( " failed\n  ! ecdsa_genkey returned %d\n", ret );
+        polarssl_printf( " failed\n  ! ecdsa_genkey returned %d\n", ret );
         goto exit;
     }
-    printf( " ok (signature length = %u)\n", (unsigned int) sig_len );
+    polarssl_printf( " ok (signature length = %u)\n", (unsigned int) sig_len );
 
     dump_buf( "  + Hash: ", hash, sizeof hash );
     dump_buf( "  + Signature: ", sig, sig_len );
@@ -187,18 +196,18 @@ int main( int argc, char *argv[] )
      * chose to use a new one in order to make it clear that the verifying
      * context only needs the public key (Q), and not the private key (d).
      */
-    printf( "  . Preparing verification context..." );
+    polarssl_printf( "  . Preparing verification context..." );
     fflush( stdout );
 
     if( ( ret = ecp_group_copy( &ctx_verify.grp, &ctx_sign.grp ) ) != 0 )
     {
-        printf( " failed\n  ! ecp_group_copy returned %d\n", ret );
+        polarssl_printf( " failed\n  ! ecp_group_copy returned %d\n", ret );
         goto exit;
     }
 
     if( ( ret = ecp_copy( &ctx_verify.Q, &ctx_sign.Q ) ) != 0 )
     {
-        printf( " failed\n  ! ecp_copy returned %d\n", ret );
+        polarssl_printf( " failed\n  ! ecp_copy returned %d\n", ret );
         goto exit;
     }
 
@@ -207,23 +216,23 @@ int main( int argc, char *argv[] )
     /*
      * Verify signature
      */
-    printf( " ok\n  . Verifying signature..." );
+    polarssl_printf( " ok\n  . Verifying signature..." );
     fflush( stdout );
 
     if( ( ret = ecdsa_read_signature( &ctx_verify,
                                       hash, sizeof( hash ),
                                       sig, sig_len ) ) != 0 )
     {
-        printf( " failed\n  ! ecdsa_read_signature returned %d\n", ret );
+        polarssl_printf( " failed\n  ! ecdsa_read_signature returned %d\n", ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
 exit:
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/pkey/key_app.c
+++ b/programs/pkey/key_app.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -44,7 +53,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or "
            "POLARSSL_PK_PARSE_C and/or POLARSSL_FS_IO not defined.\n");
     return( 0 );
 }
@@ -97,7 +106,7 @@ int main( int argc, char *argv[] )
     if( argc == 0 )
     {
     usage:
-        printf( USAGE );
+        polarssl_printf( USAGE );
         goto exit;
     }
 
@@ -136,7 +145,7 @@ int main( int argc, char *argv[] )
     {
         if( strlen( opt.password ) && strlen( opt.password_file ) )
         {
-            printf( "Error: cannot have both password and password_file\n" );
+            polarssl_printf( "Error: cannot have both password and password_file\n" );
             goto usage;
         }
 
@@ -144,16 +153,16 @@ int main( int argc, char *argv[] )
         {
             FILE *f;
 
-            printf( "\n  . Loading the password file ..." );
+            polarssl_printf( "\n  . Loading the password file ..." );
             if( ( f = fopen( opt.password_file, "rb" ) ) == NULL )
             {
-                printf( " failed\n  !  fopen returned NULL\n" );
+                polarssl_printf( " failed\n  !  fopen returned NULL\n" );
                 goto exit;
             }
             if( fgets( buf, sizeof(buf), f ) == NULL )
             {
                 fclose( f );
-                printf( "Error: fgets() failed to retrieve password\n" );
+                polarssl_printf( "Error: fgets() failed to retrieve password\n" );
                 goto exit;
             }
             fclose( f );
@@ -167,23 +176,23 @@ int main( int argc, char *argv[] )
         /*
          * 1.1. Load the key
          */
-        printf( "\n  . Loading the private key ..." );
+        polarssl_printf( "\n  . Loading the private key ..." );
         fflush( stdout );
 
         ret = pk_parse_keyfile( &pk, opt.filename, opt.password );
 
         if( ret != 0 )
         {
-            printf( " failed\n  !  pk_parse_keyfile returned -0x%04x\n", -ret );
+            polarssl_printf( " failed\n  !  pk_parse_keyfile returned -0x%04x\n", -ret );
             goto exit;
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
 
         /*
          * 1.2 Print the key
          */
-        printf( "  . Key information    ...\n" );
+        polarssl_printf( "  . Key information    ...\n" );
 #if defined(POLARSSL_RSA_C)
         if( pk_get_type( &pk ) == POLARSSL_PK_RSA )
         {
@@ -211,7 +220,7 @@ int main( int argc, char *argv[] )
         else
 #endif
         {
-            printf("Do not know how to print key information for this type\n" );
+            polarssl_printf("Do not know how to print key information for this type\n" );
             goto exit;
         }
     }
@@ -220,20 +229,20 @@ int main( int argc, char *argv[] )
         /*
          * 1.1. Load the key
          */
-        printf( "\n  . Loading the public key ..." );
+        polarssl_printf( "\n  . Loading the public key ..." );
         fflush( stdout );
 
         ret = pk_parse_public_keyfile( &pk, opt.filename );
 
         if( ret != 0 )
         {
-            printf( " failed\n  !  pk_parse_public_keyfile returned -0x%04x\n", -ret );
+            polarssl_printf( " failed\n  !  pk_parse_public_keyfile returned -0x%04x\n", -ret );
             goto exit;
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
 
-        printf( "  . Key information    ...\n" );
+        polarssl_printf( "  . Key information    ...\n" );
 #if defined(POLARSSL_RSA_C)
         if( pk_get_type( &pk ) == POLARSSL_PK_RSA )
         {
@@ -254,7 +263,7 @@ int main( int argc, char *argv[] )
         else
 #endif
         {
-            printf("Do not know how to print key information for this type\n" );
+            polarssl_printf("Do not know how to print key information for this type\n" );
             goto exit;
         }
     }
@@ -265,13 +274,13 @@ exit:
 
 #if defined(POLARSSL_ERROR_C)
     polarssl_strerror( ret, buf, sizeof(buf) );
-    printf( "  !  Last error was: %s\n", buf );
+    polarssl_printf( "  !  Last error was: %s\n", buf );
 #endif
 
     pk_free( &pk );
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/pkey/key_app_writer.c
+++ b/programs/pkey/key_app_writer.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -43,7 +52,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf( "POLARSSL_PK_WRITE_C and/or POLARSSL_FS_IO not defined.\n" );
+    polarssl_printf( "POLARSSL_PK_WRITE_C and/or POLARSSL_FS_IO not defined.\n" );
     return( 0 );
 }
 #else
@@ -204,7 +213,7 @@ int main( int argc, char *argv[] )
     {
     usage:
         ret = 1;
-        printf( USAGE );
+        polarssl_printf( USAGE );
         goto exit;
     }
 
@@ -261,13 +270,13 @@ int main( int argc, char *argv[] )
 
     if( opt.mode == MODE_NONE && opt.output_mode != OUTPUT_MODE_NONE )
     {
-        printf( "\nCannot output a key without reading one.\n");
+        polarssl_printf( "\nCannot output a key without reading one.\n");
         goto exit;
     }
 
     if( opt.mode == MODE_PUBLIC && opt.output_mode == OUTPUT_MODE_PRIVATE )
     {
-        printf( "\nCannot output a private key from a public key.\n");
+        polarssl_printf( "\nCannot output a private key from a public key.\n");
         goto exit;
     }
 
@@ -276,7 +285,7 @@ int main( int argc, char *argv[] )
         /*
          * 1.1. Load the key
          */
-        printf( "\n  . Loading the private key ..." );
+        polarssl_printf( "\n  . Loading the private key ..." );
         fflush( stdout );
 
         ret = pk_parse_keyfile( &key, opt.filename, NULL );
@@ -284,16 +293,16 @@ int main( int argc, char *argv[] )
         if( ret != 0 )
         {
             polarssl_strerror( ret, (char *) buf, sizeof(buf) );
-            printf( " failed\n  !  pk_parse_keyfile returned -0x%04x - %s\n\n", -ret, buf );
+            polarssl_printf( " failed\n  !  pk_parse_keyfile returned -0x%04x - %s\n\n", -ret, buf );
             goto exit;
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
 
         /*
          * 1.2 Print the key
          */
-        printf( "  . Key information    ...\n" );
+        polarssl_printf( "  . Key information    ...\n" );
 
 #if defined(POLARSSL_RSA_C)
         if( pk_get_type( &key ) == POLARSSL_PK_RSA )
@@ -321,7 +330,7 @@ int main( int argc, char *argv[] )
         }
         else
 #endif
-            printf("key type not supported yet\n");
+            polarssl_printf("key type not supported yet\n");
 
     }
     else if( opt.mode == MODE_PUBLIC )
@@ -329,7 +338,7 @@ int main( int argc, char *argv[] )
         /*
          * 1.1. Load the key
          */
-        printf( "\n  . Loading the public key ..." );
+        polarssl_printf( "\n  . Loading the public key ..." );
         fflush( stdout );
 
         ret = pk_parse_public_keyfile( &key, opt.filename );
@@ -337,16 +346,16 @@ int main( int argc, char *argv[] )
         if( ret != 0 )
         {
             polarssl_strerror( ret, (char *) buf, sizeof(buf) );
-            printf( " failed\n  !  pk_parse_public_key returned -0x%04x - %s\n\n", -ret, buf );
+            polarssl_printf( " failed\n  !  pk_parse_public_key returned -0x%04x - %s\n\n", -ret, buf );
             goto exit;
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
 
         /*
          * 1.2 Print the key
          */
-        printf( "  . Key information    ...\n" );
+        polarssl_printf( "  . Key information    ...\n" );
 
 #if defined(POLARSSL_RSA_C)
         if( pk_get_type( &key ) == POLARSSL_PK_RSA )
@@ -367,7 +376,7 @@ int main( int argc, char *argv[] )
         }
         else
 #endif
-            printf("key type not supported yet\n");
+            polarssl_printf("key type not supported yet\n");
     }
     else
         goto usage;
@@ -387,16 +396,16 @@ exit:
     {
 #ifdef POLARSSL_ERROR_C
         polarssl_strerror( ret, buf, sizeof( buf ) );
-        printf( " - %s\n", buf );
+        polarssl_printf( " - %s\n", buf );
 #else
-        printf("\n");
+        polarssl_printf("\n");
 #endif
     }
 
     pk_free( &key );
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/pkey/mpi_demo.c
+++ b/programs/pkey/mpi_demo.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <stdio.h>
 
 #include "polarssl/bignum.h"
@@ -39,7 +48,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_FS_IO not defined.\n");
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_FS_IO not defined.\n");
     return( 0 );
 }
 #else
@@ -59,11 +68,11 @@ int main( int argc, char *argv[] )
     mpi_read_string( &E, 10,  "257" );
     mpi_mul_mpi( &N, &P, &Q );
 
-    printf( "\n  Public key:\n\n" );
+    polarssl_printf( "\n  Public key:\n\n" );
     mpi_write_file( "  N = ", &N, 10, NULL );
     mpi_write_file( "  E = ", &E, 10, NULL );
 
-    printf( "\n  Private key:\n\n" );
+    polarssl_printf( "\n  Private key:\n\n" );
     mpi_write_file( "  P = ", &P, 10, NULL );
     mpi_write_file( "  Q = ", &Q, 10, NULL );
 
@@ -76,24 +85,24 @@ int main( int argc, char *argv[] )
     mpi_write_file( "  D = E^-1 mod (P-1)*(Q-1) = ",
                     &D, 10, NULL );
 #else
-    printf("\nTest skipped (POLARSSL_GENPRIME not defined).\n\n");
+    polarssl_printf("\nTest skipped (POLARSSL_GENPRIME not defined).\n\n");
 #endif
     mpi_read_string( &X, 10, "55555" );
     mpi_exp_mod( &Y, &X, &E, &N, NULL );
     mpi_exp_mod( &Z, &Y, &D, &N, NULL );
 
-    printf( "\n  RSA operation:\n\n" );
+    polarssl_printf( "\n  RSA operation:\n\n" );
     mpi_write_file( "  X (plaintext)  = ", &X, 10, NULL );
     mpi_write_file( "  Y (ciphertext) = X^E mod N = ", &Y, 10, NULL );
     mpi_write_file( "  Z (decrypted)  = Y^D mod N = ", &Z, 10, NULL );
-    printf( "\n" );
+    polarssl_printf( "\n" );
 
     mpi_free( &E ); mpi_free( &P ); mpi_free( &Q ); mpi_free( &N );
     mpi_free( &H ); mpi_free( &D ); mpi_free( &X ); mpi_free( &Y );
     mpi_free( &Z );
 
 #if defined(_WIN32)
-    printf( "  Press Enter to exit this program.\n" );
+    polarssl_printf( "  Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/pkey/pk_decrypt.c
+++ b/programs/pkey/pk_decrypt.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+ 
 #include <string.h>
 #include <stdio.h>
 
@@ -45,7 +54,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_PK_PARSE_C and/or "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_PK_PARSE_C and/or "
            "POLARSSL_FS_IO and/or POLARSSL_ENTROPY_C and/or "
            "POLARSSL_CTR_DRBG_C not defined.\n");
     return( 0 );
@@ -69,16 +78,16 @@ int main( int argc, char *argv[] )
 
     if( argc != 2 )
     {
-        printf( "usage: pk_decrypt <key_file>\n" );
+        polarssl_printf( "usage: pk_decrypt <key_file>\n" );
 
 #if defined(_WIN32)
-        printf( "\n" );
+        polarssl_printf( "\n" );
 #endif
 
         goto exit;
     }
 
-    printf( "\n  . Seeding the random number generator..." );
+    polarssl_printf( "\n  . Seeding the random number generator..." );
     fflush( stdout );
 
     entropy_init( &entropy );
@@ -86,18 +95,18 @@ int main( int argc, char *argv[] )
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
+        polarssl_printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
         goto exit;
     }
 
-    printf( "\n  . Reading private key from '%s'", argv[1] );
+    polarssl_printf( "\n  . Reading private key from '%s'", argv[1] );
     fflush( stdout );
 
     pk_init( &pk );
 
     if( ( ret = pk_parse_keyfile( &pk, argv[1], "" ) ) != 0 )
     {
-        printf( " failed\n  ! pk_parse_keyfile returned -0x%04x\n", -ret );
+        polarssl_printf( " failed\n  ! pk_parse_keyfile returned -0x%04x\n", -ret );
         goto exit;
     }
 
@@ -108,7 +117,7 @@ int main( int argc, char *argv[] )
 
     if( ( f = fopen( "result-enc.txt", "rb" ) ) == NULL )
     {
-        printf( "\n  ! Could not open %s\n\n", "result-enc.txt" );
+        polarssl_printf( "\n  ! Could not open %s\n\n", "result-enc.txt" );
         goto exit;
     }
 
@@ -123,19 +132,19 @@ int main( int argc, char *argv[] )
     /*
      * Decrypt the encrypted RSA data and print the result.
      */
-    printf( "\n  . Decrypting the encrypted data" );
+    polarssl_printf( "\n  . Decrypting the encrypted data" );
     fflush( stdout );
 
     if( ( ret = pk_decrypt( &pk, buf, i, result, &olen, sizeof(result),
                             ctr_drbg_random, &ctr_drbg ) ) != 0 )
     {
-        printf( " failed\n  ! pk_decrypt returned -0x%04x\n", -ret );
+        polarssl_printf( " failed\n  ! pk_decrypt returned -0x%04x\n", -ret );
         goto exit;
     }
 
-    printf( "\n  . OK\n\n" );
+    polarssl_printf( "\n  . OK\n\n" );
 
-    printf( "The decrypted result is: '%s'\n\n", result );
+    polarssl_printf( "The decrypted result is: '%s'\n\n", result );
 
     ret = 0;
 
@@ -145,11 +154,11 @@ exit:
 
 #if defined(POLARSSL_ERROR_C)
     polarssl_strerror( ret, (char *) buf, sizeof(buf) );
-    printf( "  !  Last error was: %s\n", buf );
+    polarssl_printf( "  !  Last error was: %s\n", buf );
 #endif
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/pkey/pk_encrypt.c
+++ b/programs/pkey/pk_encrypt.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdio.h>
 
@@ -45,7 +54,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_PK_PARSE_C and/or "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_PK_PARSE_C and/or "
            "POLARSSL_ENTROPY_C and/or POLARSSL_FS_IO and/or "
            "POLARSSL_CTR_DRBG_C not defined.\n");
     return( 0 );
@@ -67,16 +76,16 @@ int main( int argc, char *argv[] )
 
     if( argc != 3 )
     {
-        printf( "usage: pk_encrypt <key_file> <string of max 100 characters>\n" );
+        polarssl_printf( "usage: pk_encrypt <key_file> <string of max 100 characters>\n" );
 
 #if defined(_WIN32)
-        printf( "\n" );
+        polarssl_printf( "\n" );
 #endif
 
         goto exit;
     }
 
-    printf( "\n  . Seeding the random number generator..." );
+    polarssl_printf( "\n  . Seeding the random number generator..." );
     fflush( stdout );
 
     entropy_init( &entropy );
@@ -84,24 +93,24 @@ int main( int argc, char *argv[] )
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        printf( " failed\n  ! ctr_drbg_init returned -0x%04x\n", -ret );
+        polarssl_printf( " failed\n  ! ctr_drbg_init returned -0x%04x\n", -ret );
         goto exit;
     }
 
-    printf( "\n  . Reading public key from '%s'", argv[1] );
+    polarssl_printf( "\n  . Reading public key from '%s'", argv[1] );
     fflush( stdout );
 
     pk_init( &pk );
 
     if( ( ret = pk_parse_public_keyfile( &pk, argv[1] ) ) != 0 )
     {
-        printf( " failed\n  ! pk_parse_public_keyfile returned -0x%04x\n", -ret );
+        polarssl_printf( " failed\n  ! pk_parse_public_keyfile returned -0x%04x\n", -ret );
         goto exit;
     }
 
     if( strlen( argv[2] ) > 100 )
     {
-        printf( " Input data larger than 100 characters.\n\n" );
+        polarssl_printf( " Input data larger than 100 characters.\n\n" );
         goto exit;
     }
 
@@ -110,14 +119,14 @@ int main( int argc, char *argv[] )
     /*
      * Calculate the RSA encryption of the hash.
      */
-    printf( "\n  . Generating the encrypted value" );
+    polarssl_printf( "\n  . Generating the encrypted value" );
     fflush( stdout );
 
     if( ( ret = pk_encrypt( &pk, input, strlen( argv[2] ),
                             buf, &olen, sizeof(buf),
                             ctr_drbg_random, &ctr_drbg ) ) != 0 )
     {
-        printf( " failed\n  ! pk_encrypt returned -0x%04x\n", -ret );
+        polarssl_printf( " failed\n  ! pk_encrypt returned -0x%04x\n", -ret );
         goto exit;
     }
 
@@ -127,17 +136,17 @@ int main( int argc, char *argv[] )
     if( ( f = fopen( "result-enc.txt", "wb+" ) ) == NULL )
     {
         ret = 1;
-        printf( " failed\n  ! Could not create %s\n\n", "result-enc.txt" );
+        polarssl_printf( " failed\n  ! Could not create %s\n\n", "result-enc.txt" );
         goto exit;
     }
 
     for( i = 0; i < olen; i++ )
-        fprintf( f, "%02X%s", buf[i],
+        polarssl_fprintf( f, "%02X%s", buf[i],
                  ( i + 1 ) % 16 == 0 ? "\r\n" : " " );
 
     fclose( f );
 
-    printf( "\n  . Done (created \"%s\")\n\n", "result-enc.txt" );
+    polarssl_printf( "\n  . Done (created \"%s\")\n\n", "result-enc.txt" );
 
 exit:
     ctr_drbg_free( &ctr_drbg );
@@ -145,11 +154,11 @@ exit:
 
 #if defined(POLARSSL_ERROR_C)
     polarssl_strerror( ret, (char *) buf, sizeof(buf) );
-    printf( "  !  Last error was: %s\n", buf );
+    polarssl_printf( "  !  Last error was: %s\n", buf );
 #endif
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -32,6 +32,7 @@
 #if defined(POLARSSL_PLATFORM_C)
 #include "polarssl/platform.h"
 #else
+#define polarssl_snprintf   snprintf
 #define polarssl_printf     printf
 #define polarssl_fprintf    fprintf
 #define polarssl_malloc     malloc
@@ -139,7 +140,7 @@ int main( int argc, char *argv[] )
     /*
      * Write the signature into <filename>-sig.txt
      */
-    snprintf( filename, sizeof(filename), "%s.sig", argv[2] );
+    polarssl_snprintf( filename, sizeof(filename), "%s.sig", argv[2] );
 
     if( ( f = fopen( filename, "wb+" ) ) == NULL )
     {

--- a/programs/pkey/pk_sign.c
+++ b/programs/pkey/pk_sign.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdio.h>
 
@@ -52,7 +61,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_ENTROPY_C and/or "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_ENTROPY_C and/or "
            "POLARSSL_SHA1_C and/or "
            "POLARSSL_PK_PARSE_C and/or POLARSSL_FS_IO and/or "
            "POLARSSL_CTR_DRBG_C not defined.\n");
@@ -77,33 +86,33 @@ int main( int argc, char *argv[] )
 
     if( argc != 3 )
     {
-        printf( "usage: pk_sign <key_file> <filename>\n" );
+        polarssl_printf( "usage: pk_sign <key_file> <filename>\n" );
 
 #if defined(_WIN32)
-        printf( "\n" );
+        polarssl_printf( "\n" );
 #endif
 
         goto exit;
     }
 
-    printf( "\n  . Seeding the random number generator..." );
+    polarssl_printf( "\n  . Seeding the random number generator..." );
     fflush( stdout );
 
     if( ( ret = ctr_drbg_init( &ctr_drbg, entropy_func, &entropy,
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        printf( " failed\n  ! ctr_drbg_init returned -0x%04x\n", -ret );
+        polarssl_printf( " failed\n  ! ctr_drbg_init returned -0x%04x\n", -ret );
         goto exit;
     }
 
-    printf( "\n  . Reading private key from '%s'", argv[1] );
+    polarssl_printf( "\n  . Reading private key from '%s'", argv[1] );
     fflush( stdout );
 
     if( ( ret = pk_parse_keyfile( &pk, argv[1], "" ) ) != 0 )
     {
         ret = 1;
-        printf( " failed\n  ! Could not open '%s'\n", argv[1] );
+        polarssl_printf( " failed\n  ! Could not open '%s'\n", argv[1] );
         goto exit;
     }
 
@@ -111,19 +120,19 @@ int main( int argc, char *argv[] )
      * Compute the SHA-1 hash of the input file,
      * then calculate the signature of the hash.
      */
-    printf( "\n  . Generating the SHA-1 signature" );
+    polarssl_printf( "\n  . Generating the SHA-1 signature" );
     fflush( stdout );
 
     if( ( ret = sha1_file( argv[2], hash ) ) != 0 )
     {
-        printf( " failed\n  ! Could not open or read %s\n\n", argv[2] );
+        polarssl_printf( " failed\n  ! Could not open or read %s\n\n", argv[2] );
         goto exit;
     }
 
     if( ( ret = pk_sign( &pk, POLARSSL_MD_SHA1, hash, 0, buf, &olen,
                          ctr_drbg_random, &ctr_drbg ) ) != 0 )
     {
-        printf( " failed\n  ! pk_sign returned -0x%04x\n", -ret );
+        polarssl_printf( " failed\n  ! pk_sign returned -0x%04x\n", -ret );
         goto exit;
     }
 
@@ -135,19 +144,19 @@ int main( int argc, char *argv[] )
     if( ( f = fopen( filename, "wb+" ) ) == NULL )
     {
         ret = 1;
-        printf( " failed\n  ! Could not create %s\n\n", filename );
+        polarssl_printf( " failed\n  ! Could not create %s\n\n", filename );
         goto exit;
     }
 
     if( fwrite( buf, 1, olen, f ) != olen )
     {
-        printf( "failed\n  ! fwrite failed\n\n" );
+        polarssl_printf( "failed\n  ! fwrite failed\n\n" );
         goto exit;
     }
 
     fclose( f );
 
-    printf( "\n  . Done (created \"%s\")\n\n", filename );
+    polarssl_printf( "\n  . Done (created \"%s\")\n\n", filename );
 
 exit:
     pk_free( &pk );
@@ -156,11 +165,11 @@ exit:
 
 #if defined(POLARSSL_ERROR_C)
     polarssl_strerror( ret, (char *) buf, sizeof(buf) );
-    printf( "  !  Last error was: %s\n", buf );
+    polarssl_printf( "  !  Last error was: %s\n", buf );
 #endif
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/pkey/pk_verify.c
+++ b/programs/pkey/pk_verify.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdio.h>
 
@@ -49,7 +58,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or "
            "POLARSSL_SHA1_C and/or POLARSSL_PK_PARSE_C and/or "
            "POLARSSL_FS_IO not defined.\n");
     return( 0 );
@@ -69,21 +78,21 @@ int main( int argc, char *argv[] )
 
     if( argc != 3 )
     {
-        printf( "usage: pk_verify <key_file> <filename>\n" );
+        polarssl_printf( "usage: pk_verify <key_file> <filename>\n" );
 
 #if defined(_WIN32)
-        printf( "\n" );
+        polarssl_printf( "\n" );
 #endif
 
         goto exit;
     }
 
-    printf( "\n  . Reading public key from '%s'", argv[1] );
+    polarssl_printf( "\n  . Reading public key from '%s'", argv[1] );
     fflush( stdout );
 
     if( ( ret = pk_parse_public_keyfile( &pk, argv[1] ) ) != 0 )
     {
-        printf( " failed\n  ! pk_parse_public_keyfile returned -0x%04x\n", -ret );
+        polarssl_printf( " failed\n  ! pk_parse_public_keyfile returned -0x%04x\n", -ret );
         goto exit;
     }
 
@@ -95,7 +104,7 @@ int main( int argc, char *argv[] )
 
     if( ( f = fopen( filename, "rb" ) ) == NULL )
     {
-        printf( "\n  ! Could not open %s\n\n", filename );
+        polarssl_printf( "\n  ! Could not open %s\n\n", filename );
         goto exit;
     }
 
@@ -108,23 +117,23 @@ int main( int argc, char *argv[] )
      * Compute the SHA-1 hash of the input file and compare
      * it with the hash decrypted from the signature.
      */
-    printf( "\n  . Verifying the SHA-1 signature" );
+    polarssl_printf( "\n  . Verifying the SHA-1 signature" );
     fflush( stdout );
 
     if( ( ret = sha1_file( argv[2], hash ) ) != 0 )
     {
-        printf( " failed\n  ! Could not open or read %s\n\n", argv[2] );
+        polarssl_printf( " failed\n  ! Could not open or read %s\n\n", argv[2] );
         goto exit;
     }
 
     if( ( ret = pk_verify( &pk, POLARSSL_MD_SHA1, hash, 0,
                            buf, i ) ) != 0 )
     {
-        printf( " failed\n  ! pk_verify returned -0x%04x\n", -ret );
+        polarssl_printf( " failed\n  ! pk_verify returned -0x%04x\n", -ret );
         goto exit;
     }
 
-    printf( "\n  . OK (the decrypted SHA-1 hash matches)\n\n" );
+    polarssl_printf( "\n  . OK (the decrypted SHA-1 hash matches)\n\n" );
 
     ret = 0;
 
@@ -133,11 +142,11 @@ exit:
 
 #if defined(POLARSSL_ERROR_C)
     polarssl_strerror( ret, (char *) buf, sizeof(buf) );
-    printf( "  !  Last error was: %s\n", buf );
+    polarssl_printf( "  !  Last error was: %s\n", buf );
 #endif
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/pkey/pk_verify.c
+++ b/programs/pkey/pk_verify.c
@@ -32,6 +32,7 @@
 #if defined(POLARSSL_PLATFORM_C)
 #include "polarssl/platform.h"
 #else
+#define polarssl_snprintf   snprintf
 #define polarssl_printf     printf
 #define polarssl_fprintf    fprintf
 #define polarssl_malloc     malloc
@@ -100,7 +101,7 @@ int main( int argc, char *argv[] )
      * Extract the signature from the text file
      */
     ret = 1;
-    snprintf( filename, sizeof(filename), "%s.sig", argv[2] );
+    polarssl_snprintf( filename, sizeof(filename), "%s.sig", argv[2] );
 
     if( ( f = fopen( filename, "rb" ) ) == NULL )
     {

--- a/programs/pkey/rsa_decrypt.c
+++ b/programs/pkey/rsa_decrypt.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdio.h>
 
@@ -44,7 +53,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_RSA_C and/or "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_RSA_C and/or "
            "POLARSSL_FS_IO and/or POLARSSL_ENTROPY_C and/or "
            "POLARSSL_CTR_DRBG_C not defined.\n");
     return( 0 );
@@ -68,16 +77,16 @@ int main( int argc, char *argv[] )
 
     if( argc != 1 )
     {
-        printf( "usage: rsa_decrypt\n" );
+        polarssl_printf( "usage: rsa_decrypt\n" );
 
 #if defined(_WIN32)
-        printf( "\n" );
+        polarssl_printf( "\n" );
 #endif
 
         goto exit;
     }
 
-    printf( "\n  . Seeding the random number generator..." );
+    polarssl_printf( "\n  . Seeding the random number generator..." );
     fflush( stdout );
 
     entropy_init( &entropy );
@@ -85,16 +94,16 @@ int main( int argc, char *argv[] )
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
+        polarssl_printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
         goto exit;
     }
 
-    printf( "\n  . Reading private key from rsa_priv.txt" );
+    polarssl_printf( "\n  . Reading private key from rsa_priv.txt" );
     fflush( stdout );
 
     if( ( f = fopen( "rsa_priv.txt", "rb" ) ) == NULL )
     {
-        printf( " failed\n  ! Could not open rsa_priv.txt\n" \
+        polarssl_printf( " failed\n  ! Could not open rsa_priv.txt\n" \
                 "  ! Please run rsa_genkey first\n\n" );
         goto exit;
     }
@@ -110,7 +119,7 @@ int main( int argc, char *argv[] )
         ( ret = mpi_read_file( &rsa.DQ, 16, f ) ) != 0 ||
         ( ret = mpi_read_file( &rsa.QP, 16, f ) ) != 0 )
     {
-        printf( " failed\n  ! mpi_read_file returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! mpi_read_file returned %d\n\n", ret );
         goto exit;
     }
 
@@ -125,7 +134,7 @@ int main( int argc, char *argv[] )
 
     if( ( f = fopen( "result-enc.txt", "rb" ) ) == NULL )
     {
-        printf( "\n  ! Could not open %s\n\n", "result-enc.txt" );
+        polarssl_printf( "\n  ! Could not open %s\n\n", "result-enc.txt" );
         goto exit;
     }
 
@@ -139,27 +148,27 @@ int main( int argc, char *argv[] )
 
     if( i != rsa.len )
     {
-        printf( "\n  ! Invalid RSA signature format\n\n" );
+        polarssl_printf( "\n  ! Invalid RSA signature format\n\n" );
         goto exit;
     }
 
     /*
      * Decrypt the encrypted RSA data and print the result.
      */
-    printf( "\n  . Decrypting the encrypted data" );
+    polarssl_printf( "\n  . Decrypting the encrypted data" );
     fflush( stdout );
 
     if( ( ret = rsa_pkcs1_decrypt( &rsa, ctr_drbg_random, &ctr_drbg,
                                    RSA_PRIVATE, &i, buf, result,
                                    1024 ) ) != 0 )
     {
-        printf( " failed\n  ! rsa_pkcs1_decrypt returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! rsa_pkcs1_decrypt returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( "\n  . OK\n\n" );
+    polarssl_printf( "\n  . OK\n\n" );
 
-    printf( "The decrypted result is: '%s'\n\n", result );
+    polarssl_printf( "The decrypted result is: '%s'\n\n", result );
 
     ret = 0;
 
@@ -168,7 +177,7 @@ exit:
     entropy_free( &entropy );
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/pkey/rsa_encrypt.c
+++ b/programs/pkey/rsa_encrypt.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdio.h>
 
@@ -44,7 +53,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_RSA_C and/or "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_RSA_C and/or "
            "POLARSSL_ENTROPY_C and/or POLARSSL_FS_IO and/or "
            "POLARSSL_CTR_DRBG_C not defined.\n");
     return( 0 );
@@ -66,16 +75,16 @@ int main( int argc, char *argv[] )
 
     if( argc != 2 )
     {
-        printf( "usage: rsa_encrypt <string of max 100 characters>\n" );
+        polarssl_printf( "usage: rsa_encrypt <string of max 100 characters>\n" );
 
 #if defined(_WIN32)
-        printf( "\n" );
+        polarssl_printf( "\n" );
 #endif
 
         goto exit;
     }
 
-    printf( "\n  . Seeding the random number generator..." );
+    polarssl_printf( "\n  . Seeding the random number generator..." );
     fflush( stdout );
 
     entropy_init( &entropy );
@@ -83,17 +92,17 @@ int main( int argc, char *argv[] )
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
+        polarssl_printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
         goto exit;
     }
 
-    printf( "\n  . Reading public key from rsa_pub.txt" );
+    polarssl_printf( "\n  . Reading public key from rsa_pub.txt" );
     fflush( stdout );
 
     if( ( f = fopen( "rsa_pub.txt", "rb" ) ) == NULL )
     {
         ret = 1;
-        printf( " failed\n  ! Could not open rsa_pub.txt\n" \
+        polarssl_printf( " failed\n  ! Could not open rsa_pub.txt\n" \
                 "  ! Please run rsa_genkey first\n\n" );
         goto exit;
     }
@@ -103,7 +112,7 @@ int main( int argc, char *argv[] )
     if( ( ret = mpi_read_file( &rsa.N, 16, f ) ) != 0 ||
         ( ret = mpi_read_file( &rsa.E, 16, f ) ) != 0 )
     {
-        printf( " failed\n  ! mpi_read_file returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! mpi_read_file returned %d\n\n", ret );
         goto exit;
     }
 
@@ -113,7 +122,7 @@ int main( int argc, char *argv[] )
 
     if( strlen( argv[1] ) > 100 )
     {
-        printf( " Input data larger than 100 characters.\n\n" );
+        polarssl_printf( " Input data larger than 100 characters.\n\n" );
         goto exit;
     }
 
@@ -122,14 +131,14 @@ int main( int argc, char *argv[] )
     /*
      * Calculate the RSA encryption of the hash.
      */
-    printf( "\n  . Generating the RSA encrypted value" );
+    polarssl_printf( "\n  . Generating the RSA encrypted value" );
     fflush( stdout );
 
     if( ( ret = rsa_pkcs1_encrypt( &rsa, ctr_drbg_random, &ctr_drbg,
                                    RSA_PUBLIC, strlen( argv[1] ),
                                    input, buf ) ) != 0 )
     {
-        printf( " failed\n  ! rsa_pkcs1_encrypt returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! rsa_pkcs1_encrypt returned %d\n\n", ret );
         goto exit;
     }
 
@@ -139,24 +148,24 @@ int main( int argc, char *argv[] )
     if( ( f = fopen( "result-enc.txt", "wb+" ) ) == NULL )
     {
         ret = 1;
-        printf( " failed\n  ! Could not create %s\n\n", "result-enc.txt" );
+        polarssl_printf( " failed\n  ! Could not create %s\n\n", "result-enc.txt" );
         goto exit;
     }
 
     for( i = 0; i < rsa.len; i++ )
-        fprintf( f, "%02X%s", buf[i],
+        polarssl_fprintf( f, "%02X%s", buf[i],
                  ( i + 1 ) % 16 == 0 ? "\r\n" : " " );
 
     fclose( f );
 
-    printf( "\n  . Done (created \"%s\")\n\n", "result-enc.txt" );
+    polarssl_printf( "\n  . Done (created \"%s\")\n\n", "result-enc.txt" );
 
 exit:
     ctr_drbg_free( &ctr_drbg );
     entropy_free( &entropy );
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/pkey/rsa_genkey.c
+++ b/programs/pkey/rsa_genkey.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <stdio.h>
 
 #include "polarssl/entropy.h"
@@ -48,7 +57,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_ENTROPY_C and/or "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_ENTROPY_C and/or "
            "POLARSSL_RSA_C and/or POLARSSL_GENPRIME and/or "
            "POLARSSL_FS_IO and/or POLARSSL_CTR_DRBG_C not defined.\n");
     return( 0 );
@@ -67,7 +76,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf( "\n  . Seeding the random number generator..." );
+    polarssl_printf( "\n  . Seeding the random number generator..." );
     fflush( stdout );
 
     entropy_init( &entropy );
@@ -75,11 +84,11 @@ int main( int argc, char *argv[] )
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
+        polarssl_printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
         goto exit;
     }
 
-    printf( " ok\n  . Generating the RSA key [ %d-bit ]...", KEY_SIZE );
+    polarssl_printf( " ok\n  . Generating the RSA key [ %d-bit ]...", KEY_SIZE );
     fflush( stdout );
 
     rsa_init( &rsa, RSA_PKCS_V15, 0 );
@@ -87,16 +96,16 @@ int main( int argc, char *argv[] )
     if( ( ret = rsa_gen_key( &rsa, ctr_drbg_random, &ctr_drbg, KEY_SIZE,
                              EXPONENT ) ) != 0 )
     {
-        printf( " failed\n  ! rsa_gen_key returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! rsa_gen_key returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( " ok\n  . Exporting the public  key in rsa_pub.txt...." );
+    polarssl_printf( " ok\n  . Exporting the public  key in rsa_pub.txt...." );
     fflush( stdout );
 
     if( ( fpub = fopen( "rsa_pub.txt", "wb+" ) ) == NULL )
     {
-        printf( " failed\n  ! could not open rsa_pub.txt for writing\n\n" );
+        polarssl_printf( " failed\n  ! could not open rsa_pub.txt for writing\n\n" );
         ret = 1;
         goto exit;
     }
@@ -104,16 +113,16 @@ int main( int argc, char *argv[] )
     if( ( ret = mpi_write_file( "N = ", &rsa.N, 16, fpub ) ) != 0 ||
         ( ret = mpi_write_file( "E = ", &rsa.E, 16, fpub ) ) != 0 )
     {
-        printf( " failed\n  ! mpi_write_file returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! mpi_write_file returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( " ok\n  . Exporting the private key in rsa_priv.txt..." );
+    polarssl_printf( " ok\n  . Exporting the private key in rsa_priv.txt..." );
     fflush( stdout );
 
     if( ( fpriv = fopen( "rsa_priv.txt", "wb+" ) ) == NULL )
     {
-        printf( " failed\n  ! could not open rsa_priv.txt for writing\n" );
+        polarssl_printf( " failed\n  ! could not open rsa_priv.txt for writing\n" );
         ret = 1;
         goto exit;
     }
@@ -127,11 +136,11 @@ int main( int argc, char *argv[] )
         ( ret = mpi_write_file( "DQ = ", &rsa.DQ, 16, fpriv ) ) != 0 ||
         ( ret = mpi_write_file( "QP = ", &rsa.QP, 16, fpriv ) ) != 0 )
     {
-        printf( " failed\n  ! mpi_write_file returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! mpi_write_file returned %d\n\n", ret );
         goto exit;
     }
 /*
-    printf( " ok\n  . Generating the certificate..." );
+    polarssl_printf( " ok\n  . Generating the certificate..." );
 
     x509write_init_raw( &cert );
     x509write_add_pubkey( &cert, &rsa );
@@ -143,7 +152,7 @@ int main( int argc, char *argv[] )
     x509write_crtfile( &cert, "cert.pem", X509_OUTPUT_PEM );
     x509write_free_raw( &cert );
 */
-    printf( " ok\n\n" );
+    polarssl_printf( " ok\n\n" );
 
 exit:
 
@@ -158,7 +167,7 @@ exit:
     entropy_free( &entropy );
 
 #if defined(_WIN32)
-    printf( "  Press Enter to exit this program.\n" );
+    polarssl_printf( "  Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/pkey/rsa_sign.c
+++ b/programs/pkey/rsa_sign.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdio.h>
 
@@ -42,7 +51,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_RSA_C and/or "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_RSA_C and/or "
            "POLARSSL_SHA1_C and/or POLARSSL_FS_IO not defined.\n");
     return( 0 );
 }
@@ -60,22 +69,22 @@ int main( int argc, char *argv[] )
 
     if( argc != 2 )
     {
-        printf( "usage: rsa_sign <filename>\n" );
+        polarssl_printf( "usage: rsa_sign <filename>\n" );
 
 #if defined(_WIN32)
-        printf( "\n" );
+        polarssl_printf( "\n" );
 #endif
 
         goto exit;
     }
 
-    printf( "\n  . Reading private key from rsa_priv.txt" );
+    polarssl_printf( "\n  . Reading private key from rsa_priv.txt" );
     fflush( stdout );
 
     if( ( f = fopen( "rsa_priv.txt", "rb" ) ) == NULL )
     {
         ret = 1;
-        printf( " failed\n  ! Could not open rsa_priv.txt\n" \
+        polarssl_printf( " failed\n  ! Could not open rsa_priv.txt\n" \
                 "  ! Please run rsa_genkey first\n\n" );
         goto exit;
     }
@@ -91,7 +100,7 @@ int main( int argc, char *argv[] )
         ( ret = mpi_read_file( &rsa.DQ, 16, f ) ) != 0 ||
         ( ret = mpi_read_file( &rsa.QP, 16, f ) ) != 0 )
     {
-        printf( " failed\n  ! mpi_read_file returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! mpi_read_file returned %d\n\n", ret );
         goto exit;
     }
 
@@ -99,11 +108,11 @@ int main( int argc, char *argv[] )
 
     fclose( f );
 
-    printf( "\n  . Checking the private key" );
+    polarssl_printf( "\n  . Checking the private key" );
     fflush( stdout );
     if( ( ret = rsa_check_privkey( &rsa ) ) != 0 )
     {
-        printf( " failed\n  ! rsa_check_privkey failed with -0x%0x\n", -ret );
+        polarssl_printf( " failed\n  ! rsa_check_privkey failed with -0x%0x\n", -ret );
         goto exit;
     }
 
@@ -111,19 +120,19 @@ int main( int argc, char *argv[] )
      * Compute the SHA-1 hash of the input file,
      * then calculate the RSA signature of the hash.
      */
-    printf( "\n  . Generating the RSA/SHA-1 signature" );
+    polarssl_printf( "\n  . Generating the RSA/SHA-1 signature" );
     fflush( stdout );
 
     if( ( ret = sha1_file( argv[1], hash ) ) != 0 )
     {
-        printf( " failed\n  ! Could not open or read %s\n\n", argv[1] );
+        polarssl_printf( " failed\n  ! Could not open or read %s\n\n", argv[1] );
         goto exit;
     }
 
     if( ( ret = rsa_pkcs1_sign( &rsa, NULL, NULL, RSA_PRIVATE, POLARSSL_MD_SHA1,
                                 20, hash, buf ) ) != 0 )
     {
-        printf( " failed\n  ! rsa_pkcs1_sign returned -0x%0x\n\n", -ret );
+        polarssl_printf( " failed\n  ! rsa_pkcs1_sign returned -0x%0x\n\n", -ret );
         goto exit;
     }
 
@@ -135,22 +144,22 @@ int main( int argc, char *argv[] )
     if( ( f = fopen( argv[1], "wb+" ) ) == NULL )
     {
         ret = 1;
-        printf( " failed\n  ! Could not create %s\n\n", argv[1] );
+        polarssl_printf( " failed\n  ! Could not create %s\n\n", argv[1] );
         goto exit;
     }
 
     for( i = 0; i < rsa.len; i++ )
-        fprintf( f, "%02X%s", buf[i],
+        polarssl_fprintf( f, "%02X%s", buf[i],
                  ( i + 1 ) % 16 == 0 ? "\r\n" : " " );
 
     fclose( f );
 
-    printf( "\n  . Done (created \"%s\")\n\n", argv[1] );
+    polarssl_printf( "\n  . Done (created \"%s\")\n\n", argv[1] );
 
 exit:
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/pkey/rsa_sign_pss.c
+++ b/programs/pkey/rsa_sign_pss.c
@@ -32,6 +32,7 @@
 #if defined(POLARSSL_PLATFORM_C)
 #include "polarssl/platform.h"
 #else
+#define polarssl_snprintf   snprintf
 #define polarssl_printf     printf
 #define polarssl_fprintf    fprintf
 #define polarssl_malloc     malloc
@@ -149,7 +150,7 @@ int main( int argc, char *argv[] )
     /*
      * Write the signature into <filename>-sig.txt
      */
-    snprintf( filename, 512, "%s.sig", argv[2] );
+    polarssl_snprintf( filename, 512, "%s.sig", argv[2] );
 
     if( ( f = fopen( filename, "wb+" ) ) == NULL )
     {

--- a/programs/pkey/rsa_sign_pss.c
+++ b/programs/pkey/rsa_sign_pss.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdio.h>
 
@@ -52,7 +61,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_ENTROPY_C and/or "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_ENTROPY_C and/or "
            "POLARSSL_RSA_C and/or POLARSSL_SHA1_C and/or "
            "POLARSSL_PK_PARSE_C and/or POLARSSL_FS_IO and/or "
            "POLARSSL_CTR_DRBG_C not defined.\n");
@@ -77,41 +86,41 @@ int main( int argc, char *argv[] )
 
     if( argc != 3 )
     {
-        printf( "usage: rsa_sign_pss <key_file> <filename>\n" );
+        polarssl_printf( "usage: rsa_sign_pss <key_file> <filename>\n" );
 
 #if defined(_WIN32)
-        printf( "\n" );
+        polarssl_printf( "\n" );
 #endif
 
         goto exit;
     }
 
-    printf( "\n  . Seeding the random number generator..." );
+    polarssl_printf( "\n  . Seeding the random number generator..." );
     fflush( stdout );
 
     if( ( ret = ctr_drbg_init( &ctr_drbg, entropy_func, &entropy,
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
+        polarssl_printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
         goto exit;
     }
 
-    printf( "\n  . Reading private key from '%s'", argv[1] );
+    polarssl_printf( "\n  . Reading private key from '%s'", argv[1] );
     fflush( stdout );
 
     if( ( ret = pk_parse_keyfile( &pk, argv[1], "" ) ) != 0 )
     {
         ret = 1;
-        printf( " failed\n  ! Could not read key from '%s'\n", argv[1] );
-        printf( "  ! pk_parse_public_keyfile returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! Could not read key from '%s'\n", argv[1] );
+        polarssl_printf( "  ! pk_parse_public_keyfile returned %d\n\n", ret );
         goto exit;
     }
 
     if( !pk_can_do( &pk, POLARSSL_PK_RSA ) )
     {
         ret = 1;
-        printf( " failed\n  ! Key is not an RSA key\n" );
+        polarssl_printf( " failed\n  ! Key is not an RSA key\n" );
         goto exit;
     }
 
@@ -121,19 +130,19 @@ int main( int argc, char *argv[] )
      * Compute the SHA-1 hash of the input file,
      * then calculate the RSA signature of the hash.
      */
-    printf( "\n  . Generating the RSA/SHA-1 signature" );
+    polarssl_printf( "\n  . Generating the RSA/SHA-1 signature" );
     fflush( stdout );
 
     if( ( ret = sha1_file( argv[2], hash ) ) != 0 )
     {
-        printf( " failed\n  ! Could not open or read %s\n\n", argv[2] );
+        polarssl_printf( " failed\n  ! Could not open or read %s\n\n", argv[2] );
         goto exit;
     }
 
     if( ( ret = pk_sign( &pk, POLARSSL_MD_SHA1, hash, 0, buf, &olen,
                          ctr_drbg_random, &ctr_drbg ) ) != 0 )
     {
-        printf( " failed\n  ! pk_sign returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! pk_sign returned %d\n\n", ret );
         goto exit;
     }
 
@@ -145,19 +154,19 @@ int main( int argc, char *argv[] )
     if( ( f = fopen( filename, "wb+" ) ) == NULL )
     {
         ret = 1;
-        printf( " failed\n  ! Could not create %s\n\n", filename );
+        polarssl_printf( " failed\n  ! Could not create %s\n\n", filename );
         goto exit;
     }
 
     if( fwrite( buf, 1, olen, f ) != olen )
     {
-        printf( "failed\n  ! fwrite failed\n\n" );
+        polarssl_printf( "failed\n  ! fwrite failed\n\n" );
         goto exit;
     }
 
     fclose( f );
 
-    printf( "\n  . Done (created \"%s\")\n\n", filename );
+    polarssl_printf( "\n  . Done (created \"%s\")\n\n", filename );
 
 exit:
     pk_free( &pk );
@@ -165,7 +174,7 @@ exit:
     entropy_free( &entropy );
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/pkey/rsa_verify.c
+++ b/programs/pkey/rsa_verify.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdio.h>
 
@@ -42,7 +51,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_RSA_C and/or "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_RSA_C and/or "
            "POLARSSL_SHA1_C and/or POLARSSL_FS_IO not defined.\n");
     return( 0 );
 }
@@ -59,21 +68,21 @@ int main( int argc, char *argv[] )
     ret = 1;
     if( argc != 2 )
     {
-        printf( "usage: rsa_verify <filename>\n" );
+        polarssl_printf( "usage: rsa_verify <filename>\n" );
 
 #if defined(_WIN32)
-        printf( "\n" );
+        polarssl_printf( "\n" );
 #endif
 
         goto exit;
     }
 
-    printf( "\n  . Reading public key from rsa_pub.txt" );
+    polarssl_printf( "\n  . Reading public key from rsa_pub.txt" );
     fflush( stdout );
 
     if( ( f = fopen( "rsa_pub.txt", "rb" ) ) == NULL )
     {
-        printf( " failed\n  ! Could not open rsa_pub.txt\n" \
+        polarssl_printf( " failed\n  ! Could not open rsa_pub.txt\n" \
                 "  ! Please run rsa_genkey first\n\n" );
         goto exit;
     }
@@ -83,7 +92,7 @@ int main( int argc, char *argv[] )
     if( ( ret = mpi_read_file( &rsa.N, 16, f ) ) != 0 ||
         ( ret = mpi_read_file( &rsa.E, 16, f ) ) != 0 )
     {
-        printf( " failed\n  ! mpi_read_file returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! mpi_read_file returned %d\n\n", ret );
         goto exit;
     }
 
@@ -100,7 +109,7 @@ int main( int argc, char *argv[] )
 
     if( ( f = fopen( argv[1], "rb" ) ) == NULL )
     {
-        printf( "\n  ! Could not open %s\n\n", argv[1] );
+        polarssl_printf( "\n  ! Could not open %s\n\n", argv[1] );
         goto exit;
     }
 
@@ -114,7 +123,7 @@ int main( int argc, char *argv[] )
 
     if( i != rsa.len )
     {
-        printf( "\n  ! Invalid RSA signature format\n\n" );
+        polarssl_printf( "\n  ! Invalid RSA signature format\n\n" );
         goto exit;
     }
 
@@ -122,30 +131,30 @@ int main( int argc, char *argv[] )
      * Compute the SHA-1 hash of the input file and compare
      * it with the hash decrypted from the RSA signature.
      */
-    printf( "\n  . Verifying the RSA/SHA-1 signature" );
+    polarssl_printf( "\n  . Verifying the RSA/SHA-1 signature" );
     fflush( stdout );
 
     if( ( ret = sha1_file( argv[1], hash ) ) != 0 )
     {
-        printf( " failed\n  ! Could not open or read %s\n\n", argv[1] );
+        polarssl_printf( " failed\n  ! Could not open or read %s\n\n", argv[1] );
         goto exit;
     }
 
     if( ( ret = rsa_pkcs1_verify( &rsa, NULL, NULL, RSA_PUBLIC,
                                   POLARSSL_MD_SHA1, 20, hash, buf ) ) != 0 )
     {
-        printf( " failed\n  ! rsa_pkcs1_verify returned -0x%0x\n\n", -ret );
+        polarssl_printf( " failed\n  ! rsa_pkcs1_verify returned -0x%0x\n\n", -ret );
         goto exit;
     }
 
-    printf( "\n  . OK (the decrypted SHA-1 hash matches)\n\n" );
+    polarssl_printf( "\n  . OK (the decrypted SHA-1 hash matches)\n\n" );
 
     ret = 0;
 
 exit:
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/pkey/rsa_verify_pss.c
+++ b/programs/pkey/rsa_verify_pss.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdio.h>
 
@@ -50,7 +59,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_RSA_C and/or "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_RSA_C and/or "
            "POLARSSL_SHA1_C and/or POLARSSL_PK_PARSE_C and/or "
            "POLARSSL_FS_IO not defined.\n");
     return( 0 );
@@ -70,29 +79,29 @@ int main( int argc, char *argv[] )
 
     if( argc != 3 )
     {
-        printf( "usage: rsa_verify_pss <key_file> <filename>\n" );
+        polarssl_printf( "usage: rsa_verify_pss <key_file> <filename>\n" );
 
 #if defined(_WIN32)
-        printf( "\n" );
+        polarssl_printf( "\n" );
 #endif
 
         goto exit;
     }
 
-    printf( "\n  . Reading public key from '%s'", argv[1] );
+    polarssl_printf( "\n  . Reading public key from '%s'", argv[1] );
     fflush( stdout );
 
     if( ( ret = pk_parse_public_keyfile( &pk, argv[1] ) ) != 0 )
     {
-        printf( " failed\n  ! Could not read key from '%s'\n", argv[1] );
-        printf( "  ! pk_parse_public_keyfile returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! Could not read key from '%s'\n", argv[1] );
+        polarssl_printf( "  ! pk_parse_public_keyfile returned %d\n\n", ret );
         goto exit;
     }
 
     if( !pk_can_do( &pk, POLARSSL_PK_RSA ) )
     {
         ret = 1;
-        printf( " failed\n  ! Key is not an RSA key\n" );
+        polarssl_printf( " failed\n  ! Key is not an RSA key\n" );
         goto exit;
     }
 
@@ -106,7 +115,7 @@ int main( int argc, char *argv[] )
 
     if( ( f = fopen( filename, "rb" ) ) == NULL )
     {
-        printf( "\n  ! Could not open %s\n\n", filename );
+        polarssl_printf( "\n  ! Could not open %s\n\n", filename );
         goto exit;
     }
 
@@ -119,23 +128,23 @@ int main( int argc, char *argv[] )
      * Compute the SHA-1 hash of the input file and compare
      * it with the hash decrypted from the RSA signature.
      */
-    printf( "\n  . Verifying the RSA/SHA-1 signature" );
+    polarssl_printf( "\n  . Verifying the RSA/SHA-1 signature" );
     fflush( stdout );
 
     if( ( ret = sha1_file( argv[2], hash ) ) != 0 )
     {
-        printf( " failed\n  ! Could not open or read %s\n\n", argv[2] );
+        polarssl_printf( " failed\n  ! Could not open or read %s\n\n", argv[2] );
         goto exit;
     }
 
     if( ( ret = pk_verify( &pk, POLARSSL_MD_SHA1, hash, 0,
                            buf, i ) ) != 0 )
     {
-        printf( " failed\n  ! pk_verify returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! pk_verify returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( "\n  . OK (the decrypted SHA-1 hash matches)\n\n" );
+    polarssl_printf( "\n  . OK (the decrypted SHA-1 hash matches)\n\n" );
 
     ret = 0;
 
@@ -143,7 +152,7 @@ exit:
     pk_free( &pk );
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/pkey/rsa_verify_pss.c
+++ b/programs/pkey/rsa_verify_pss.c
@@ -32,6 +32,7 @@
 #if defined(POLARSSL_PLATFORM_C)
 #include "polarssl/platform.h"
 #else
+#define polarssl_snprintf   snprintf
 #define polarssl_printf     printf
 #define polarssl_fprintf    fprintf
 #define polarssl_malloc     malloc
@@ -111,7 +112,7 @@ int main( int argc, char *argv[] )
      * Extract the RSA signature from the text file
      */
     ret = 1;
-    snprintf( filename, 512, "%s.sig", argv[2] );
+    polarssl_snprintf( filename, 512, "%s.sig", argv[2] );
 
     if( ( f = fopen( filename, "rb" ) ) == NULL )
     {

--- a/programs/random/gen_entropy.c
+++ b/programs/random/gen_entropy.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include "polarssl/entropy.h"
 
 #include <stdio.h>
@@ -39,7 +48,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_ENTROPY_C not defined.\n");
+    polarssl_printf("POLARSSL_ENTROPY_C not defined.\n");
     return( 0 );
 }
 #else
@@ -52,13 +61,13 @@ int main( int argc, char *argv[] )
 
     if( argc < 2 )
     {
-        fprintf( stderr, "usage: %s <output filename>\n", argv[0] );
+        polarssl_fprintf( stderr, "usage: %s <output filename>\n", argv[0] );
         return( 1 );
     }
 
     if( ( f = fopen( argv[1], "wb+" ) ) == NULL )
     {
-        printf( "failed to open '%s' for writing.\n", argv[0] );
+        polarssl_printf( "failed to open '%s' for writing.\n", argv[0] );
         return( 1 );
     }
 
@@ -69,13 +78,13 @@ int main( int argc, char *argv[] )
         ret = entropy_func( &entropy, buf, sizeof( buf ) );
         if( ret != 0 )
         {
-            printf("failed!\n");
+            polarssl_printf("failed!\n");
             goto cleanup;
         }
 
         fwrite( buf, 1, sizeof( buf ), f );
 
-        printf( "Generating 32Mb of data in file '%s'... %04.1f" \
+        polarssl_printf( "Generating 32Mb of data in file '%s'... %04.1f" \
                 "%% done\r", argv[1], (100 * (float) (i + 1)) / k );
         fflush( stdout );
     }

--- a/programs/random/gen_random_ctr_drbg.c
+++ b/programs/random/gen_random_ctr_drbg.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include "polarssl/entropy.h"
 #include "polarssl/ctr_drbg.h"
 
@@ -40,7 +49,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_CTR_DRBG_C or POLARSSL_ENTROPY_C not defined.\n");
+    polarssl_printf("POLARSSL_CTR_DRBG_C or POLARSSL_ENTROPY_C not defined.\n");
     return( 0 );
 }
 #else
@@ -54,13 +63,13 @@ int main( int argc, char *argv[] )
 
     if( argc < 2 )
     {
-        fprintf( stderr, "usage: %s <output filename>\n", argv[0] );
+        polarssl_fprintf( stderr, "usage: %s <output filename>\n", argv[0] );
         return( 1 );
     }
 
     if( ( f = fopen( argv[1], "wb+" ) ) == NULL )
     {
-        printf( "failed to open '%s' for writing.\n", argv[0] );
+        polarssl_printf( "failed to open '%s' for writing.\n", argv[0] );
         return( 1 );
     }
 
@@ -68,7 +77,7 @@ int main( int argc, char *argv[] )
     ret = ctr_drbg_init( &ctr_drbg, entropy_func, &entropy, (const unsigned char *) "RANDOM_GEN", 10 );
     if( ret != 0 )
     {
-        printf( "failed in ctr_drbg_init: %d\n", ret );
+        polarssl_printf( "failed in ctr_drbg_init: %d\n", ret );
         goto cleanup;
     }
     ctr_drbg_set_prediction_resistance( &ctr_drbg, CTR_DRBG_PR_OFF );
@@ -78,17 +87,17 @@ int main( int argc, char *argv[] )
 
     if( ret == POLARSSL_ERR_CTR_DRBG_FILE_IO_ERROR )
     {
-        printf( "Failed to open seedfile. Generating one.\n" );
+        polarssl_printf( "Failed to open seedfile. Generating one.\n" );
         ret = ctr_drbg_write_seed_file( &ctr_drbg, "seedfile" );
         if( ret != 0 )
         {
-            printf( "failed in ctr_drbg_write_seed_file: %d\n", ret );
+            polarssl_printf( "failed in ctr_drbg_write_seed_file: %d\n", ret );
             goto cleanup;
         }
     }
     else if( ret != 0 )
     {
-        printf( "failed in ctr_drbg_update_seed_file: %d\n", ret );
+        polarssl_printf( "failed in ctr_drbg_update_seed_file: %d\n", ret );
         goto cleanup;
     }
 #endif
@@ -98,13 +107,13 @@ int main( int argc, char *argv[] )
         ret = ctr_drbg_random( &ctr_drbg, buf, sizeof( buf ) );
         if( ret != 0 )
         {
-            printf("failed!\n");
+            polarssl_printf("failed!\n");
             goto cleanup;
         }
 
         fwrite( buf, 1, sizeof( buf ), f );
 
-        printf( "Generating 32Mb of data in file '%s'... %04.1f" \
+        polarssl_printf( "Generating 32Mb of data in file '%s'... %04.1f" \
                 "%% done\r", argv[1], (100 * (float) (i + 1)) / k );
         fflush( stdout );
     }
@@ -112,7 +121,7 @@ int main( int argc, char *argv[] )
     ret = 0;
 
 cleanup:
-    printf("\n");
+    polarssl_printf("\n");
 
     fclose( f );
     ctr_drbg_free( &ctr_drbg );

--- a/programs/random/gen_random_havege.c
+++ b/programs/random/gen_random_havege.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include "polarssl/havege.h"
 
 #include <time.h>
@@ -40,7 +49,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_HAVEGE_C not defined.\n");
+    polarssl_printf("POLARSSL_HAVEGE_C not defined.\n");
     return( 0 );
 }
 #else
@@ -54,13 +63,13 @@ int main( int argc, char *argv[] )
 
     if( argc < 2 )
     {
-        fprintf( stderr, "usage: %s <output filename>\n", argv[0] );
+        polarssl_fprintf( stderr, "usage: %s <output filename>\n", argv[0] );
         return( 1 );
     }
 
     if( ( f = fopen( argv[1], "wb+" ) ) == NULL )
     {
-        printf( "failed to open '%s' for writing.\n", argv[0] );
+        polarssl_printf( "failed to open '%s' for writing.\n", argv[0] );
         return( 1 );
     }
 
@@ -72,7 +81,7 @@ int main( int argc, char *argv[] )
     {
         if( havege_random( &hs, buf, sizeof( buf ) ) != 0 )
         {
-            printf( "Failed to get random from source.\n" );
+            polarssl_printf( "Failed to get random from source.\n" );
 
             ret = 1;
             goto exit;
@@ -80,7 +89,7 @@ int main( int argc, char *argv[] )
 
         fwrite( buf, sizeof( buf ), 1, f );
 
-        printf( "Generating 32Mb of data in file '%s'... %04.1f" \
+        polarssl_printf( "Generating 32Mb of data in file '%s'... %04.1f" \
                 "%% done\r", argv[1], (100 * (float) (i + 1)) / k );
         fflush( stdout );
     }
@@ -88,7 +97,7 @@ int main( int argc, char *argv[] )
     if( t == time( NULL ) )
         t--;
 
-    printf(" \n ");
+    polarssl_printf(" \n ");
 
 exit:
     havege_free( &hs );

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -32,6 +32,7 @@
 #if defined(POLARSSL_PLATFORM_C)
 #include "polarssl/platform.h"
 #else
+#define polarssl_snprintf   snprintf
 #define polarssl_printf     printf
 #define polarssl_fprintf    fprintf
 #define polarssl_malloc     malloc
@@ -1075,7 +1076,7 @@ send_request:
     polarssl_printf( "  > Write to server:" );
     fflush( stdout );
 
-    len = snprintf( (char *) buf, sizeof(buf) - 1, GET_REQUEST,
+    len = polarssl_snprintf( (char *) buf, sizeof(buf) - 1, GET_REQUEST,
                     opt.request_page );
     tail_len = strlen( GET_REQUEST_END );
 

--- a/programs/ssl/ssl_client2.c
+++ b/programs/ssl/ssl_client2.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #if !defined(POLARSSL_ENTROPY_C) ||  \
     !defined(POLARSSL_SSL_TLS_C) || !defined(POLARSSL_SSL_CLI_C) || \
     !defined(POLARSSL_NET_C) || !defined(POLARSSL_CTR_DRBG_C)
@@ -38,7 +47,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_ENTROPY_C and/or "
+    polarssl_printf("POLARSSL_ENTROPY_C and/or "
            "POLARSSL_SSL_TLS_C and/or POLARSSL_SSL_CLI_C and/or "
            "POLARSSL_NET_C and/or POLARSSL_CTR_DRBG_C not defined.\n");
     return( 0 );
@@ -138,7 +147,7 @@ static void my_debug( void *ctx, int level, const char *str )
 {
     ((void) level);
 
-    fprintf( (FILE *) ctx, "%s", str );
+    polarssl_fprintf( (FILE *) ctx, "%s", str );
     fflush(  (FILE *) ctx  );
 }
 
@@ -189,33 +198,33 @@ static int my_verify( void *data, x509_crt *crt, int depth, int *flags )
     char buf[1024];
     ((void) data);
 
-    printf( "\nVerify requested for (Depth %d):\n", depth );
+    polarssl_printf( "\nVerify requested for (Depth %d):\n", depth );
     x509_crt_info( buf, sizeof( buf ) - 1, "", crt );
-    printf( "%s", buf );
+    polarssl_printf( "%s", buf );
 
     if( ( (*flags) & BADCERT_EXPIRED ) != 0 )
-        printf( "  ! server certificate has expired\n" );
+        polarssl_printf( "  ! server certificate has expired\n" );
 
     if( ( (*flags) & BADCERT_REVOKED ) != 0 )
-        printf( "  ! server certificate has been revoked\n" );
+        polarssl_printf( "  ! server certificate has been revoked\n" );
 
     if( ( (*flags) & BADCERT_CN_MISMATCH ) != 0 )
-        printf( "  ! CN mismatch\n" );
+        polarssl_printf( "  ! CN mismatch\n" );
 
     if( ( (*flags) & BADCERT_NOT_TRUSTED ) != 0 )
-        printf( "  ! self-signed or not signed by a trusted CA\n" );
+        polarssl_printf( "  ! self-signed or not signed by a trusted CA\n" );
 
     if( ( (*flags) & BADCRL_NOT_TRUSTED ) != 0 )
-        printf( "  ! CRL not trusted\n" );
+        polarssl_printf( "  ! CRL not trusted\n" );
 
     if( ( (*flags) & BADCRL_EXPIRED ) != 0 )
-        printf( "  ! CRL expired\n" );
+        polarssl_printf( "  ! CRL expired\n" );
 
     if( ( (*flags) & BADCERT_OTHER ) != 0 )
-        printf( "  ! other (unknown) flag\n" );
+        polarssl_printf( "  ! other (unknown) flag\n" );
 
     if ( ( *flags ) == 0 )
-        printf( "  This certificate has no flags\n" );
+        polarssl_printf( "  This certificate has no flags\n" );
 
     return( 0 );
 }
@@ -370,19 +379,19 @@ int main( int argc, char *argv[] )
         if( ret == 0 )
             ret = 1;
 
-        printf( USAGE );
+        polarssl_printf( USAGE );
 
         list = ssl_list_ciphersuites();
         while( *list )
         {
-            printf(" %-42s", ssl_get_ciphersuite_name( *list ) );
+            polarssl_printf(" %-42s", ssl_get_ciphersuite_name( *list ) );
             list++;
             if( !*list )
                 break;
-            printf(" %s\n", ssl_get_ciphersuite_name( *list ) );
+            polarssl_printf(" %s\n", ssl_get_ciphersuite_name( *list ) );
             list++;
         }
-        printf("\n");
+        polarssl_printf("\n");
         goto exit;
     }
 
@@ -616,14 +625,14 @@ int main( int argc, char *argv[] )
         if( opt.max_version != -1 &&
             ciphersuite_info->min_minor_ver > opt.max_version )
         {
-            printf("forced ciphersuite not allowed with this protocol version\n");
+            polarssl_printf("forced ciphersuite not allowed with this protocol version\n");
             ret = 2;
             goto usage;
         }
         if( opt.min_version != -1 &&
             ciphersuite_info->max_minor_ver < opt.min_version )
         {
-            printf("forced ciphersuite not allowed with this protocol version\n");
+            polarssl_printf("forced ciphersuite not allowed with this protocol version\n");
             ret = 2;
             goto usage;
         }
@@ -644,7 +653,7 @@ int main( int argc, char *argv[] )
 
         if( strlen( opt.psk ) % 2 != 0 )
         {
-            printf("pre-shared key not valid hex\n");
+            polarssl_printf("pre-shared key not valid hex\n");
             goto exit;
         }
 
@@ -661,7 +670,7 @@ int main( int argc, char *argv[] )
                 c -= 'A' - 10;
             else
             {
-                printf("pre-shared key not valid hex\n");
+                polarssl_printf("pre-shared key not valid hex\n");
                 goto exit;
             }
             psk[ j / 2 ] = c << 4;
@@ -675,7 +684,7 @@ int main( int argc, char *argv[] )
                 c -= 'A' - 10;
             else
             {
-                printf("pre-shared key not valid hex\n");
+                polarssl_printf("pre-shared key not valid hex\n");
                 goto exit;
             }
             psk[ j / 2 ] |= c;
@@ -706,7 +715,7 @@ int main( int argc, char *argv[] )
     /*
      * 0. Initialize the RNG and the session data
      */
-    printf( "\n  . Seeding the random number generator..." );
+    polarssl_printf( "\n  . Seeding the random number generator..." );
     fflush( stdout );
 
     entropy_init( &entropy );
@@ -714,17 +723,17 @@ int main( int argc, char *argv[] )
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        printf( " failed\n  ! ctr_drbg_init returned -0x%x\n", -ret );
+        polarssl_printf( " failed\n  ! ctr_drbg_init returned -0x%x\n", -ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
 #if defined(POLARSSL_X509_CRT_PARSE_C)
     /*
      * 1.1. Load the trusted CA
      */
-    printf( "  . Loading the CA root certificate ..." );
+    polarssl_printf( "  . Loading the CA root certificate ..." );
     fflush( stdout );
 
 #if defined(POLARSSL_FS_IO)
@@ -746,23 +755,23 @@ int main( int argc, char *argv[] )
 #else
     {
         ret = 1;
-        printf("POLARSSL_CERTS_C not defined.");
+        polarssl_printf("POLARSSL_CERTS_C not defined.");
     }
 #endif
     if( ret < 0 )
     {
-        printf( " failed\n  !  x509_crt_parse returned -0x%x\n\n", -ret );
+        polarssl_printf( " failed\n  !  x509_crt_parse returned -0x%x\n\n", -ret );
         goto exit;
     }
 
-    printf( " ok (%d skipped)\n", ret );
+    polarssl_printf( " ok (%d skipped)\n", ret );
 
     /*
      * 1.2. Load own certificate and private key
      *
      * (can be skipped if client authentication is not required)
      */
-    printf( "  . Loading the client cert. and key..." );
+    polarssl_printf( "  . Loading the client cert. and key..." );
     fflush( stdout );
 
 #if defined(POLARSSL_FS_IO)
@@ -779,12 +788,12 @@ int main( int argc, char *argv[] )
 #else
     {
         ret = 1;
-        printf("POLARSSL_CERTS_C not defined.");
+        polarssl_printf("POLARSSL_CERTS_C not defined.");
     }
 #endif
     if( ret != 0 )
     {
-        printf( " failed\n  !  x509_crt_parse returned -0x%x\n\n", -ret );
+        polarssl_printf( " failed\n  !  x509_crt_parse returned -0x%x\n\n", -ret );
         goto exit;
     }
 
@@ -802,16 +811,16 @@ int main( int argc, char *argv[] )
 #else
     {
         ret = 1;
-        printf("POLARSSL_CERTS_C not defined.");
+        polarssl_printf("POLARSSL_CERTS_C not defined.");
     }
 #endif
     if( ret != 0 )
     {
-        printf( " failed\n  !  pk_parse_key returned -0x%x\n\n", -ret );
+        polarssl_printf( " failed\n  !  pk_parse_key returned -0x%x\n\n", -ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 #endif /* POLARSSL_X509_CRT_PARSE_C */
 
     /*
@@ -820,14 +829,14 @@ int main( int argc, char *argv[] )
     if( opt.server_addr == NULL)
         opt.server_addr = opt.server_name;
 
-    printf( "  . Connecting to tcp/%s/%-4d...", opt.server_addr,
+    polarssl_printf( "  . Connecting to tcp/%s/%-4d...", opt.server_addr,
                                                 opt.server_port );
     fflush( stdout );
 
     if( ( ret = net_connect( &server_fd, opt.server_addr,
                                          opt.server_port ) ) != 0 )
     {
-        printf( " failed\n  ! net_connect returned -0x%x\n\n", -ret );
+        polarssl_printf( " failed\n  ! net_connect returned -0x%x\n\n", -ret );
         goto exit;
     }
 
@@ -837,25 +846,25 @@ int main( int argc, char *argv[] )
         ret = net_set_block( server_fd );
     if( ret != 0 )
     {
-        printf( " failed\n  ! net_set_(non)block() returned -0x%x\n\n", -ret );
+        polarssl_printf( " failed\n  ! net_set_(non)block() returned -0x%x\n\n", -ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 3. Setup stuff
      */
-    printf( "  . Setting up the SSL/TLS structure..." );
+    polarssl_printf( "  . Setting up the SSL/TLS structure..." );
     fflush( stdout );
 
     if( ( ret = ssl_init( &ssl ) ) != 0 )
     {
-        printf( " failed\n  ! ssl_init returned -0x%x\n\n", -ret );
+        polarssl_printf( " failed\n  ! ssl_init returned -0x%x\n\n", -ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
 #if defined(POLARSSL_X509_CRT_PARSE_C)
     if( opt.debug_level > 0 )
@@ -868,7 +877,7 @@ int main( int argc, char *argv[] )
 #if defined(POLARSSL_SSL_MAX_FRAGMENT_LENGTH)
     if( ( ret = ssl_set_max_frag_len( &ssl, opt.mfl_code ) ) != 0 )
     {
-        printf( " failed\n  ! ssl_set_max_frag_len returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! ssl_set_max_frag_len returned %d\n\n", ret );
         goto exit;
     }
 #endif
@@ -877,7 +886,7 @@ int main( int argc, char *argv[] )
     if( opt.trunc_hmac != 0 )
         if( ( ret = ssl_set_truncated_hmac( &ssl, SSL_TRUNC_HMAC_ENABLED ) ) != 0 )
         {
-            printf( " failed\n  ! ssl_set_truncated_hmac returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_set_truncated_hmac returned %d\n\n", ret );
             goto exit;
         }
 #endif
@@ -886,7 +895,7 @@ int main( int argc, char *argv[] )
     if( opt.alpn_string != NULL )
         if( ( ret = ssl_set_alpn_protocols( &ssl, alpn_list ) ) != 0 )
         {
-            printf( " failed\n  ! ssl_set_alpn_protocols returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_set_alpn_protocols returned %d\n\n", ret );
             goto exit;
         }
 #endif
@@ -902,7 +911,7 @@ int main( int argc, char *argv[] )
 #if defined(POLARSSL_SSL_SESSION_TICKETS)
     if( ( ret = ssl_set_session_tickets( &ssl, opt.tickets ) ) != 0 )
     {
-        printf( " failed\n  ! ssl_set_session_tickets returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! ssl_set_session_tickets returned %d\n\n", ret );
         goto exit;
     }
 #endif
@@ -924,7 +933,7 @@ int main( int argc, char *argv[] )
     {
         if( ( ret = ssl_set_own_cert( &ssl, &clicert, &pkey ) ) != 0 )
         {
-            printf( " failed\n  ! ssl_set_own_cert returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_set_own_cert returned %d\n\n", ret );
             goto exit;
         }
     }
@@ -935,7 +944,7 @@ int main( int argc, char *argv[] )
                              (const unsigned char *) opt.psk_identity,
                              strlen( opt.psk_identity ) ) ) != 0 )
     {
-        printf( " failed\n  ! ssl_set_psk returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! ssl_set_psk returned %d\n\n", ret );
         goto exit;
     }
 #endif
@@ -943,7 +952,7 @@ int main( int argc, char *argv[] )
 #if defined(POLARSSL_SSL_SERVER_NAME_INDICATION)
     if( ( ret = ssl_set_hostname( &ssl, opt.server_name ) ) != 0 )
     {
-        printf( " failed\n  ! ssl_set_hostname returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! ssl_set_hostname returned %d\n\n", ret );
         goto exit;
     }
 #endif
@@ -956,86 +965,86 @@ int main( int argc, char *argv[] )
     /*
      * 4. Handshake
      */
-    printf( "  . Performing the SSL/TLS handshake..." );
+    polarssl_printf( "  . Performing the SSL/TLS handshake..." );
     fflush( stdout );
 
     while( ( ret = ssl_handshake( &ssl ) ) != 0 )
     {
         if( ret != POLARSSL_ERR_NET_WANT_READ && ret != POLARSSL_ERR_NET_WANT_WRITE )
         {
-            printf( " failed\n  ! ssl_handshake returned -0x%x\n", -ret );
+            polarssl_printf( " failed\n  ! ssl_handshake returned -0x%x\n", -ret );
             if( ret == POLARSSL_ERR_X509_CERT_VERIFY_FAILED )
-                printf(
+                polarssl_printf(
                     "    Unable to verify the server's certificate. "
                         "Either it is invalid,\n"
                     "    or you didn't set ca_file or ca_path "
                         "to an appropriate value.\n"
                     "    Alternatively, you may want to use "
                         "auth_mode=optional for testing purposes.\n" );
-            printf( "\n" );
+            polarssl_printf( "\n" );
             goto exit;
         }
     }
 
-    printf( " ok\n    [ Protocol is %s ]\n    [ Ciphersuite is %s ]\n",
+    polarssl_printf( " ok\n    [ Protocol is %s ]\n    [ Ciphersuite is %s ]\n",
             ssl_get_version( &ssl ), ssl_get_ciphersuite( &ssl ) );
 
 #if defined(POLARSSL_SSL_ALPN)
     if( opt.alpn_string != NULL )
     {
         const char *alp = ssl_get_alpn_protocol( &ssl );
-        printf( "    [ Application Layer Protocol is %s ]\n",
+        polarssl_printf( "    [ Application Layer Protocol is %s ]\n",
                 alp ? alp : "(none)" );
     }
 #endif
 
     if( opt.reconnect != 0 )
     {
-        printf("  . Saving session for reuse..." );
+        polarssl_printf("  . Saving session for reuse..." );
         fflush( stdout );
 
         if( ( ret = ssl_get_session( &ssl, &saved_session ) ) != 0 )
         {
-            printf( " failed\n  ! ssl_get_session returned -0x%x\n\n", -ret );
+            polarssl_printf( " failed\n  ! ssl_get_session returned -0x%x\n\n", -ret );
             goto exit;
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
     }
 
 #if defined(POLARSSL_X509_CRT_PARSE_C)
     /*
      * 5. Verify the server certificate
      */
-    printf( "  . Verifying peer X.509 certificate..." );
+    polarssl_printf( "  . Verifying peer X.509 certificate..." );
 
     if( ( ret = ssl_get_verify_result( &ssl ) ) != 0 )
     {
-        printf( " failed\n" );
+        polarssl_printf( " failed\n" );
 
         if( ( ret & BADCERT_EXPIRED ) != 0 )
-            printf( "  ! server certificate has expired\n" );
+            polarssl_printf( "  ! server certificate has expired\n" );
 
         if( ( ret & BADCERT_REVOKED ) != 0 )
-            printf( "  ! server certificate has been revoked\n" );
+            polarssl_printf( "  ! server certificate has been revoked\n" );
 
         if( ( ret & BADCERT_CN_MISMATCH ) != 0 )
-            printf( "  ! CN mismatch (expected CN=%s)\n", opt.server_name );
+            polarssl_printf( "  ! CN mismatch (expected CN=%s)\n", opt.server_name );
 
         if( ( ret & BADCERT_NOT_TRUSTED ) != 0 )
-            printf( "  ! self-signed or not signed by a trusted CA\n" );
+            polarssl_printf( "  ! self-signed or not signed by a trusted CA\n" );
 
-        printf( "\n" );
+        polarssl_printf( "\n" );
     }
     else
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
 
     if( ssl_get_peer_cert( &ssl ) != NULL )
     {
-        printf( "  . Peer certificate information    ...\n" );
+        polarssl_printf( "  . Peer certificate information    ...\n" );
         x509_crt_info( (char *) buf, sizeof( buf ) - 1, "      ",
                        ssl_get_peer_cert( &ssl ) );
-        printf( "%s\n", buf );
+        polarssl_printf( "%s\n", buf );
     }
 #endif /* POLARSSL_X509_CRT_PARSE_C */
 
@@ -1045,25 +1054,25 @@ int main( int argc, char *argv[] )
          * Perform renegotiation (this must be done when the server is waiting
          * for input from our side).
          */
-        printf( "  . Performing renegotiation..." );
+        polarssl_printf( "  . Performing renegotiation..." );
         fflush( stdout );
         while( ( ret = ssl_renegotiate( &ssl ) ) != 0 )
         {
             if( ret != POLARSSL_ERR_NET_WANT_READ &&
                 ret != POLARSSL_ERR_NET_WANT_WRITE )
             {
-                printf( " failed\n  ! ssl_renegotiate returned %d\n\n", ret );
+                polarssl_printf( " failed\n  ! ssl_renegotiate returned %d\n\n", ret );
                 goto exit;
             }
         }
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
     }
 
     /*
      * 6. Write the GET request
      */
 send_request:
-    printf( "  > Write to server:" );
+    polarssl_printf( "  > Write to server:" );
     fflush( stdout );
 
     len = snprintf( (char *) buf, sizeof(buf) - 1, GET_REQUEST,
@@ -1098,19 +1107,19 @@ send_request:
         {
             if( ret != POLARSSL_ERR_NET_WANT_READ && ret != POLARSSL_ERR_NET_WANT_WRITE )
             {
-                printf( " failed\n  ! ssl_write returned -0x%x\n\n", -ret );
+                polarssl_printf( " failed\n  ! ssl_write returned -0x%x\n\n", -ret );
                 goto exit;
             }
         }
     }
 
     buf[written] = '\0';
-    printf( " %d bytes written in %d fragments\n\n%s\n", written, frags, (char *) buf );
+    polarssl_printf( " %d bytes written in %d fragments\n\n%s\n", written, frags, (char *) buf );
 
     /*
      * 7. Read the HTTP response
      */
-    printf( "  < Read from server:" );
+    polarssl_printf( "  < Read from server:" );
     fflush( stdout );
 
     do
@@ -1128,25 +1137,25 @@ send_request:
             switch( ret )
             {
                 case POLARSSL_ERR_SSL_PEER_CLOSE_NOTIFY:
-                    printf( " connection was closed gracefully\n" );
+                    polarssl_printf( " connection was closed gracefully\n" );
                     ret = 0;
                     goto close_notify;
 
                 case 0:
                 case POLARSSL_ERR_NET_CONN_RESET:
-                    printf( " connection was reset by peer\n" );
+                    polarssl_printf( " connection was reset by peer\n" );
                     ret = 0;
                     goto reconnect;
 
                 default:
-                    printf( " ssl_read returned -0x%x\n", -ret );
+                    polarssl_printf( " ssl_read returned -0x%x\n", -ret );
                     goto exit;
             }
         }
 
         len = ret;
         buf[len] = '\0';
-        printf( " %d bytes read\n\n%s", len, (char *) buf );
+        polarssl_printf( " %d bytes read\n\n%s", len, (char *) buf );
 
         /* End of message should be detected according to the syntax of the
          * application protocol (eg HTTP), just use a dummy test here. */
@@ -1168,13 +1177,13 @@ send_request:
      * 8. Done, cleanly close the connection
      */
 close_notify:
-    printf( "  . Closing the connection..." );
+    polarssl_printf( "  . Closing the connection..." );
 
     while( ( ret = ssl_close_notify( &ssl ) ) < 0 )
     {
         if( ret == POLARSSL_ERR_NET_CONN_RESET )
         {
-            printf( " ok (already closed by peer)\n" );
+            polarssl_printf( " ok (already closed by peer)\n" );
             ret = 0;
             goto reconnect;
         }
@@ -1182,12 +1191,12 @@ close_notify:
         if( ret != POLARSSL_ERR_NET_WANT_READ &&
             ret != POLARSSL_ERR_NET_WANT_WRITE )
         {
-            printf( " failed\n  ! ssl_close_notify returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_close_notify returned %d\n\n", ret );
             goto reconnect;
         }
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 9. Reconnect?
@@ -1204,25 +1213,25 @@ reconnect:
             m_sleep( 1000 * opt.reco_delay );
 #endif
 
-        printf( "  . Reconnecting with saved session..." );
+        polarssl_printf( "  . Reconnecting with saved session..." );
         fflush( stdout );
 
         if( ( ret = ssl_session_reset( &ssl ) ) != 0 )
         {
-            printf( " failed\n  ! ssl_session_reset returned -0x%x\n\n", -ret );
+            polarssl_printf( " failed\n  ! ssl_session_reset returned -0x%x\n\n", -ret );
             goto exit;
         }
 
         if( ( ret = ssl_set_session( &ssl, &saved_session ) ) != 0 )
         {
-            printf( " failed\n  ! ssl_set_session returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_set_session returned %d\n\n", ret );
             goto exit;
         }
 
         if( ( ret = net_connect( &server_fd, opt.server_name,
                         opt.server_port ) ) != 0 )
         {
-            printf( " failed\n  ! net_connect returned -0x%x\n\n", -ret );
+            polarssl_printf( " failed\n  ! net_connect returned -0x%x\n\n", -ret );
             goto exit;
         }
 
@@ -1231,12 +1240,12 @@ reconnect:
             if( ret != POLARSSL_ERR_NET_WANT_READ &&
                 ret != POLARSSL_ERR_NET_WANT_WRITE )
             {
-                printf( " failed\n  ! ssl_handshake returned -0x%x\n\n", -ret );
+                polarssl_printf( " failed\n  ! ssl_handshake returned -0x%x\n\n", -ret );
                 goto exit;
             }
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
 
         goto send_request;
     }
@@ -1250,7 +1259,7 @@ exit:
     {
         char error_buf[100];
         polarssl_strerror( ret, error_buf, 100 );
-        printf("Last error was: -0x%X - %s\n\n", -ret, error_buf );
+        polarssl_printf("Last error was: -0x%X - %s\n\n", -ret, error_buf );
     }
 #endif
 
@@ -1268,7 +1277,7 @@ exit:
     entropy_free( &entropy );
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/ssl/ssl_fork_server.c
+++ b/programs/ssl/ssl_fork_server.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+ 
 #if defined(_WIN32)
 #include <windows.h>
 #endif
@@ -65,7 +74,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_CERTS_C and/or POLARSSL_ENTROPY_C "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_CERTS_C and/or POLARSSL_ENTROPY_C "
            "and/or POLARSSL_SSL_TLS_C and/or POLARSSL_SSL_SRV_C and/or "
            "POLARSSL_NET_C and/or POLARSSL_RSA_C and/or "
            "POLARSSL_CTR_DRBG_C and/or POLARSSL_X509_CRT_PARSE_C and/or "
@@ -78,7 +87,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("_WIN32 defined. This application requires fork() and signals "
+    polarssl_printf("_WIN32 defined. This application requires fork() and signals "
            "to work correctly.\n");
     return( 0 );
 }
@@ -90,7 +99,7 @@ static void my_debug( void *ctx, int level, const char *str )
 {
     if( level < DEBUG_LEVEL )
     {
-        fprintf( (FILE *) ctx, "%s", str );
+        polarssl_fprintf( (FILE *) ctx, "%s", str );
         fflush(  (FILE *) ctx  );
     }
 }
@@ -123,23 +132,23 @@ int main( int argc, char *argv[] )
     /*
      * 0. Initial seeding of the RNG
      */
-    printf( "\n  . Initial seeding of the random generator..." );
+    polarssl_printf( "\n  . Initial seeding of the random generator..." );
     fflush( stdout );
 
     if( ( ret = ctr_drbg_init( &ctr_drbg, entropy_func, &entropy,
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
+        polarssl_printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 1. Load the certificates and private RSA key
      */
-    printf( "  . Loading the server cert. and key..." );
+    polarssl_printf( "  . Loading the server cert. and key..." );
     fflush( stdout );
 
     /*
@@ -151,7 +160,7 @@ int main( int argc, char *argv[] )
                           strlen( test_srv_crt ) );
     if( ret != 0 )
     {
-        printf( " failed\n  !  x509_crt_parse returned %d\n\n", ret );
+        polarssl_printf( " failed\n  !  x509_crt_parse returned %d\n\n", ret );
         goto exit;
     }
 
@@ -159,7 +168,7 @@ int main( int argc, char *argv[] )
                           strlen( test_ca_list ) );
     if( ret != 0 )
     {
-        printf( " failed\n  !  x509_crt_parse returned %d\n\n", ret );
+        polarssl_printf( " failed\n  !  x509_crt_parse returned %d\n\n", ret );
         goto exit;
     }
 
@@ -167,25 +176,25 @@ int main( int argc, char *argv[] )
                           strlen( test_srv_key ), NULL, 0 );
     if( ret != 0 )
     {
-        printf( " failed\n  !  pk_parse_key returned %d\n\n", ret );
+        polarssl_printf( " failed\n  !  pk_parse_key returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 2. Setup the listening TCP socket
      */
-    printf( "  . Bind on https://localhost:4433/ ..." );
+    polarssl_printf( "  . Bind on https://localhost:4433/ ..." );
     fflush( stdout );
 
     if( ( ret = net_bind( &listen_fd, NULL, 4433 ) ) != 0 )
     {
-        printf( " failed\n  ! net_bind returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! net_bind returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     while( 1 )
     {
@@ -195,16 +204,16 @@ int main( int argc, char *argv[] )
         client_fd = -1;
         memset( &ssl, 0, sizeof( ssl ) );
 
-        printf( "  . Waiting for a remote connection ..." );
+        polarssl_printf( "  . Waiting for a remote connection ..." );
         fflush( stdout );
 
         if( ( ret = net_accept( listen_fd, &client_fd, NULL ) ) != 0 )
         {
-            printf( " failed\n  ! net_accept returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! net_accept returned %d\n\n", ret );
             goto exit;
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
 
         /*
          * 3.5. Forking server thread
@@ -212,16 +221,16 @@ int main( int argc, char *argv[] )
 
         pid = fork();
 
-        printf( "  . Forking to handle connection ..." );
+        polarssl_printf( "  . Forking to handle connection ..." );
         fflush( stdout );
 
         if( pid < 0 )
         {
-            printf(" failed\n  ! fork returned %d\n\n", pid );
+            polarssl_printf(" failed\n  ! fork returned %d\n\n", pid );
             goto exit;
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
 
         if( pid != 0 )
         {
@@ -229,7 +238,7 @@ int main( int argc, char *argv[] )
                                          (const unsigned char *) "parent",
                                          6 ) ) != 0 )
             {
-                printf( " failed\n  ! ctr_drbg_reseed returned %d\n", ret );
+                polarssl_printf( " failed\n  ! ctr_drbg_reseed returned %d\n", ret );
                 goto exit;
             }
 
@@ -242,24 +251,24 @@ int main( int argc, char *argv[] )
         /*
          * 4. Setup stuff
          */
-        printf( "  . Setting up the SSL data...." );
+        polarssl_printf( "  . Setting up the SSL data...." );
         fflush( stdout );
 
         if( ( ret = ctr_drbg_reseed( &ctr_drbg,
                                      (const unsigned char *) "child",
                                      5 ) ) != 0 )
         {
-            printf( " failed\n  ! ctr_drbg_reseed returned %d\n", ret );
+            polarssl_printf( " failed\n  ! ctr_drbg_reseed returned %d\n", ret );
             goto exit;
         }
 
         if( ( ret = ssl_init( &ssl ) ) != 0 )
         {
-            printf( " failed\n  ! ssl_init returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_init returned %d\n\n", ret );
             goto exit;
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
 
         ssl_set_endpoint( &ssl, SSL_IS_SERVER );
         ssl_set_authmode( &ssl, SSL_VERIFY_NONE );
@@ -272,31 +281,31 @@ int main( int argc, char *argv[] )
         ssl_set_ca_chain( &ssl, srvcert.next, NULL, NULL );
         if( ( ret = ssl_set_own_cert( &ssl, &srvcert, &pkey ) ) != 0 )
         {
-            printf( " failed\n  ! ssl_set_own_cert returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_set_own_cert returned %d\n\n", ret );
             goto exit;
         }
 
         /*
          * 5. Handshake
          */
-        printf( "  . Performing the SSL/TLS handshake..." );
+        polarssl_printf( "  . Performing the SSL/TLS handshake..." );
         fflush( stdout );
 
         while( ( ret = ssl_handshake( &ssl ) ) != 0 )
         {
             if( ret != POLARSSL_ERR_NET_WANT_READ && ret != POLARSSL_ERR_NET_WANT_WRITE )
             {
-                printf( " failed\n  ! ssl_handshake returned %d\n\n", ret );
+                polarssl_printf( " failed\n  ! ssl_handshake returned %d\n\n", ret );
                 goto exit;
             }
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
 
         /*
          * 6. Read the HTTP Request
          */
-        printf( "  < Read from client:" );
+        polarssl_printf( "  < Read from client:" );
         fflush( stdout );
 
         do
@@ -313,15 +322,15 @@ int main( int argc, char *argv[] )
                 switch( ret )
                 {
                     case POLARSSL_ERR_SSL_PEER_CLOSE_NOTIFY:
-                        printf( " connection was closed gracefully\n" );
+                        polarssl_printf( " connection was closed gracefully\n" );
                         break;
 
                     case POLARSSL_ERR_NET_CONN_RESET:
-                        printf( " connection was reset by peer\n" );
+                        polarssl_printf( " connection was reset by peer\n" );
                         break;
 
                     default:
-                        printf( " ssl_read returned %d\n", ret );
+                        polarssl_printf( " ssl_read returned %d\n", ret );
                         break;
                 }
 
@@ -329,14 +338,14 @@ int main( int argc, char *argv[] )
             }
 
             len = ret;
-            printf( " %d bytes read\n\n%s", len, (char *) buf );
+            polarssl_printf( " %d bytes read\n\n%s", len, (char *) buf );
         }
         while( 0 );
 
         /*
          * 7. Write the 200 Response
          */
-        printf( "  > Write to client:" );
+        polarssl_printf( "  > Write to client:" );
         fflush( stdout );
 
         len = sprintf( (char *) buf, HTTP_RESPONSE,
@@ -348,18 +357,18 @@ int main( int argc, char *argv[] )
             {
                 if( ret == POLARSSL_ERR_NET_CONN_RESET )
                 {
-                    printf( " failed\n  ! peer closed the connection\n\n" );
+                    polarssl_printf( " failed\n  ! peer closed the connection\n\n" );
                     goto exit;
                 }
 
                 if( ret != POLARSSL_ERR_NET_WANT_READ && ret != POLARSSL_ERR_NET_WANT_WRITE )
                 {
-                    printf( " failed\n  ! ssl_write returned %d\n\n", ret );
+                    polarssl_printf( " failed\n  ! ssl_write returned %d\n\n", ret );
                     goto exit;
                 }
             }
             len = ret;
-            printf( " %d bytes written\n\n%s\n", len, (char *) buf );
+            polarssl_printf( " %d bytes written\n\n%s\n", len, (char *) buf );
 
             m_sleep( 1000 );
         }
@@ -380,7 +389,7 @@ exit:
     entropy_free( &entropy );
 
 #if defined(_WIN32)
-    printf( "  Press Enter to exit this program.\n" );
+    polarssl_printf( "  Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/ssl/ssl_mail_client.c
+++ b/programs/ssl/ssl_mail_client.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -73,7 +82,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_ENTROPY_C and/or "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_ENTROPY_C and/or "
            "POLARSSL_SSL_TLS_C and/or POLARSSL_SSL_CLI_C and/or "
            "POLARSSL_NET_C and/or POLARSSL_RSA_C and/or "
            "POLARSSL_CTR_DRBG_C and/or POLARSSL_X509_CRT_PARSE_C "
@@ -123,7 +132,7 @@ static void my_debug( void *ctx, int level, const char *str )
 {
     if( level < opt.debug_level )
     {
-        fprintf( (FILE *) ctx, "%s", str );
+        polarssl_fprintf( (FILE *) ctx, "%s", str );
         fflush(  (FILE *) ctx  );
     }
 }
@@ -137,7 +146,7 @@ static int do_handshake( ssl_context *ssl, struct options *opt )
     /*
      * 4. Handshake
      */
-    printf( "  . Performing the SSL/TLS handshake..." );
+    polarssl_printf( "  . Performing the SSL/TLS handshake..." );
     fflush( stdout );
 
     while( ( ret = ssl_handshake( ssl ) ) != 0 )
@@ -147,45 +156,45 @@ static int do_handshake( ssl_context *ssl, struct options *opt )
 #if defined(POLARSSL_ERROR_C)
             polarssl_strerror( ret, (char *) buf, 1024 );
 #endif
-            printf( " failed\n  ! ssl_handshake returned %d: %s\n\n", ret, buf );
+            polarssl_printf( " failed\n  ! ssl_handshake returned %d: %s\n\n", ret, buf );
             return( -1 );
         }
     }
 
-    printf( " ok\n    [ Ciphersuite is %s ]\n",
+    polarssl_printf( " ok\n    [ Ciphersuite is %s ]\n",
             ssl_get_ciphersuite( ssl ) );
 
     /*
      * 5. Verify the server certificate
      */
-    printf( "  . Verifying peer X.509 certificate..." );
+    polarssl_printf( "  . Verifying peer X.509 certificate..." );
 
     /* In real life, we may want to bail out when ret != 0 */
     if( ( ret = ssl_get_verify_result( ssl ) ) != 0 )
     {
-        printf( " failed\n" );
+        polarssl_printf( " failed\n" );
 
         if( ( ret & BADCERT_EXPIRED ) != 0 )
-            printf( "  ! server certificate has expired\n" );
+            polarssl_printf( "  ! server certificate has expired\n" );
 
         if( ( ret & BADCERT_REVOKED ) != 0 )
-            printf( "  ! server certificate has been revoked\n" );
+            polarssl_printf( "  ! server certificate has been revoked\n" );
 
         if( ( ret & BADCERT_CN_MISMATCH ) != 0 )
-            printf( "  ! CN mismatch (expected CN=%s)\n", opt->server_name );
+            polarssl_printf( "  ! CN mismatch (expected CN=%s)\n", opt->server_name );
 
         if( ( ret & BADCERT_NOT_TRUSTED ) != 0 )
-            printf( "  ! self-signed or not signed by a trusted CA\n" );
+            polarssl_printf( "  ! self-signed or not signed by a trusted CA\n" );
 
-        printf( "\n" );
+        polarssl_printf( "\n" );
     }
     else
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
 
-    printf( "  . Peer certificate information    ...\n" );
+    polarssl_printf( "  . Peer certificate information    ...\n" );
     x509_crt_info( (char *) buf, sizeof( buf ) - 1, "      ",
                    ssl_get_peer_cert( ssl ) );
-    printf( "%s\n", buf );
+    polarssl_printf( "%s\n", buf );
 
     return( 0 );
 }
@@ -194,12 +203,12 @@ static int write_ssl_data( ssl_context *ssl, unsigned char *buf, size_t len )
 {
     int ret;
 
-    printf("\n%s", buf);
+    polarssl_printf("\n%s", buf);
     while( len && ( ret = ssl_write( ssl, buf, len ) ) <= 0 )
     {
         if( ret != POLARSSL_ERR_NET_WANT_READ && ret != POLARSSL_ERR_NET_WANT_WRITE )
         {
-            printf( " failed\n  ! ssl_write returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_write returned %d\n\n", ret );
             return -1;
         }
     }
@@ -214,12 +223,12 @@ static int write_ssl_and_get_response( ssl_context *ssl, unsigned char *buf, siz
     char code[4];
     size_t i, idx = 0;
 
-    printf("\n%s", buf);
+    polarssl_printf("\n%s", buf);
     while( len && ( ret = ssl_write( ssl, buf, len ) ) <= 0 )
     {
         if( ret != POLARSSL_ERR_NET_WANT_READ && ret != POLARSSL_ERR_NET_WANT_WRITE )
         {
-            printf( " failed\n  ! ssl_write returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_write returned %d\n\n", ret );
             return -1;
         }
     }
@@ -238,11 +247,11 @@ static int write_ssl_and_get_response( ssl_context *ssl, unsigned char *buf, siz
 
         if( ret <= 0 )
         {
-            printf( "failed\n  ! ssl_read returned %d\n\n", ret );
+            polarssl_printf( "failed\n  ! ssl_read returned %d\n\n", ret );
             return -1;
         }
 
-        printf("\n%s", data);
+        polarssl_printf("\n%s", data);
         len = ret;
         for( i = 0; i < len; i++ )
         {
@@ -272,10 +281,10 @@ static int write_and_get_response( int sock_fd, unsigned char *buf, size_t len )
     char code[4];
     size_t i, idx = 0;
 
-    printf("\n%s", buf);
+    polarssl_printf("\n%s", buf);
     if( len && ( ret = write( sock_fd, buf, len ) ) <= 0 )
     {
-        printf( " failed\n  ! ssl_write returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! ssl_write returned %d\n\n", ret );
             return -1;
     }
 
@@ -287,12 +296,12 @@ static int write_and_get_response( int sock_fd, unsigned char *buf, size_t len )
 
         if( ret <= 0 )
         {
-            printf( "failed\n  ! read returned %d\n\n", ret );
+            polarssl_printf( "failed\n  ! read returned %d\n\n", ret );
             return -1;
         }
 
         data[len] = '\0';
-        printf("\n%s", data);
+        polarssl_printf("\n%s", data);
         len = ret;
         for( i = 0; i < len; i++ )
         {
@@ -383,15 +392,15 @@ int main( int argc, char *argv[] )
     if( argc == 0 )
     {
     usage:
-        printf( USAGE );
+        polarssl_printf( USAGE );
 
         list = ssl_list_ciphersuites();
         while( *list )
         {
-            printf("    %s\n", ssl_get_ciphersuite_name( *list ) );
+            polarssl_printf("    %s\n", ssl_get_ciphersuite_name( *list ) );
             list++;
         }
-        printf("\n");
+        polarssl_printf("\n");
         goto exit;
     }
 
@@ -474,7 +483,7 @@ int main( int argc, char *argv[] )
     /*
      * 0. Initialize the RNG and the session data
      */
-    printf( "\n  . Seeding the random number generator..." );
+    polarssl_printf( "\n  . Seeding the random number generator..." );
     fflush( stdout );
 
     entropy_init( &entropy );
@@ -482,16 +491,16 @@ int main( int argc, char *argv[] )
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
+        polarssl_printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 1.1. Load the trusted CA
      */
-    printf( "  . Loading the CA root certificate ..." );
+    polarssl_printf( "  . Loading the CA root certificate ..." );
     fflush( stdout );
 
 #if defined(POLARSSL_FS_IO)
@@ -505,23 +514,23 @@ int main( int argc, char *argv[] )
 #else
     {
         ret = 1;
-        printf("POLARSSL_CERTS_C not defined.");
+        polarssl_printf("POLARSSL_CERTS_C not defined.");
     }
 #endif
     if( ret < 0 )
     {
-        printf( " failed\n  !  x509_crt_parse returned %d\n\n", ret );
+        polarssl_printf( " failed\n  !  x509_crt_parse returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( " ok (%d skipped)\n", ret );
+    polarssl_printf( " ok (%d skipped)\n", ret );
 
     /*
      * 1.2. Load own certificate and private key
      *
      * (can be skipped if client authentication is not required)
      */
-    printf( "  . Loading the client cert. and key..." );
+    polarssl_printf( "  . Loading the client cert. and key..." );
     fflush( stdout );
 
 #if defined(POLARSSL_FS_IO)
@@ -535,12 +544,12 @@ int main( int argc, char *argv[] )
 #else
     {
         ret = -1;
-        printf("POLARSSL_CERTS_C not defined.");
+        polarssl_printf("POLARSSL_CERTS_C not defined.");
     }
 #endif
     if( ret != 0 )
     {
-        printf( " failed\n  !  x509_crt_parse returned %d\n\n", ret );
+        polarssl_printf( " failed\n  !  x509_crt_parse returned %d\n\n", ret );
         goto exit;
     }
 
@@ -555,46 +564,46 @@ int main( int argc, char *argv[] )
 #else
     {
         ret = -1;
-        printf("POLARSSL_CERTS_C not defined.");
+        polarssl_printf("POLARSSL_CERTS_C not defined.");
     }
 #endif
     if( ret != 0 )
     {
-        printf( " failed\n  !  pk_parse_key returned %d\n\n", ret );
+        polarssl_printf( " failed\n  !  pk_parse_key returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 2. Start the connection
      */
-    printf( "  . Connecting to tcp/%s/%-4d...", opt.server_name,
+    polarssl_printf( "  . Connecting to tcp/%s/%-4d...", opt.server_name,
                                                 opt.server_port );
     fflush( stdout );
 
     if( ( ret = net_connect( &server_fd, opt.server_name,
                                          opt.server_port ) ) != 0 )
     {
-        printf( " failed\n  ! net_connect returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! net_connect returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 3. Setup stuff
      */
-    printf( "  . Setting up the SSL/TLS structure..." );
+    polarssl_printf( "  . Setting up the SSL/TLS structure..." );
     fflush( stdout );
 
     if( ( ret = ssl_init( &ssl ) ) != 0 )
     {
-        printf( " failed\n  ! ssl_init returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! ssl_init returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     ssl_set_endpoint( &ssl, SSL_IS_CLIENT );
     /* OPTIONAL is not optimal for security,
@@ -612,14 +621,14 @@ int main( int argc, char *argv[] )
     ssl_set_ca_chain( &ssl, &cacert, NULL, opt.server_name );
     if( ( ret = ssl_set_own_cert( &ssl, &clicert, &pkey ) ) != 0 )
     {
-        printf( " failed\n  ! ssl_set_own_cert returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! ssl_set_own_cert returned %d\n\n", ret );
         goto exit;
     }
 
 #if defined(POLARSSL_SSL_SERVER_NAME_INDICATION)
     if( ( ret = ssl_set_hostname( &ssl, opt.server_name ) ) != 0 )
     {
-        printf( " failed\n  ! ssl_set_hostname returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! ssl_set_hostname returned %d\n\n", ret );
         goto exit;
     }
 #endif
@@ -629,19 +638,19 @@ int main( int argc, char *argv[] )
         if( do_handshake( &ssl, &opt ) != 0 )
             goto exit;
 
-        printf( "  > Get header from server:" );
+        polarssl_printf( "  > Get header from server:" );
         fflush( stdout );
 
         ret = write_ssl_and_get_response( &ssl, buf, 0 );
         if( ret < 200 || ret > 299 )
         {
-            printf( " failed\n  ! server responded with %d\n\n", ret );
+            polarssl_printf( " failed\n  ! server responded with %d\n\n", ret );
             goto exit;
         }
 
-        printf(" ok\n" );
+        polarssl_printf(" ok\n" );
 
-        printf( "  > Write EHLO to server:" );
+        polarssl_printf( "  > Write EHLO to server:" );
         fflush( stdout );
 
         gethostname( hostname, 32 );
@@ -649,25 +658,25 @@ int main( int argc, char *argv[] )
         ret = write_ssl_and_get_response( &ssl, buf, len );
         if( ret < 200 || ret > 299 )
         {
-            printf( " failed\n  ! server responded with %d\n\n", ret );
+            polarssl_printf( " failed\n  ! server responded with %d\n\n", ret );
             goto exit;
         }
     }
     else
     {
-        printf( "  > Get header from server:" );
+        polarssl_printf( "  > Get header from server:" );
         fflush( stdout );
 
         ret = write_and_get_response( server_fd, buf, 0 );
         if( ret < 200 || ret > 299 )
         {
-            printf( " failed\n  ! server responded with %d\n\n", ret );
+            polarssl_printf( " failed\n  ! server responded with %d\n\n", ret );
             goto exit;
         }
 
-        printf(" ok\n" );
+        polarssl_printf(" ok\n" );
 
-        printf( "  > Write EHLO to server:" );
+        polarssl_printf( "  > Write EHLO to server:" );
         fflush( stdout );
 
         gethostname( hostname, 32 );
@@ -675,13 +684,13 @@ int main( int argc, char *argv[] )
         ret = write_and_get_response( server_fd, buf, len );
         if( ret < 200 || ret > 299 )
         {
-            printf( " failed\n  ! server responded with %d\n\n", ret );
+            polarssl_printf( " failed\n  ! server responded with %d\n\n", ret );
             goto exit;
         }
 
-        printf(" ok\n" );
+        polarssl_printf(" ok\n" );
 
-        printf( "  > Write STARTTLS to server:" );
+        polarssl_printf( "  > Write STARTTLS to server:" );
         fflush( stdout );
 
         gethostname( hostname, 32 );
@@ -689,11 +698,11 @@ int main( int argc, char *argv[] )
         ret = write_and_get_response( server_fd, buf, len );
         if( ret < 200 || ret > 299 )
         {
-            printf( " failed\n  ! server responded with %d\n\n", ret );
+            polarssl_printf( " failed\n  ! server responded with %d\n\n", ret );
             goto exit;
         }
 
-        printf(" ok\n" );
+        polarssl_printf(" ok\n" );
 
         if( do_handshake( &ssl, &opt ) != 0 )
             goto exit;
@@ -702,20 +711,20 @@ int main( int argc, char *argv[] )
 #if defined(POLARSSL_BASE64_C)
     if( opt.authentication )
     {
-        printf( "  > Write AUTH LOGIN to server:" );
+        polarssl_printf( "  > Write AUTH LOGIN to server:" );
         fflush( stdout );
 
         len = sprintf( (char *) buf, "AUTH LOGIN\r\n" );
         ret = write_ssl_and_get_response( &ssl, buf, len );
         if( ret < 200 || ret > 399 )
         {
-            printf( " failed\n  ! server responded with %d\n\n", ret );
+            polarssl_printf( " failed\n  ! server responded with %d\n\n", ret );
             goto exit;
         }
 
-        printf(" ok\n" );
+        polarssl_printf(" ok\n" );
 
-        printf( "  > Write username to server: %s", opt.user_name );
+        polarssl_printf( "  > Write username to server: %s", opt.user_name );
         fflush( stdout );
 
         n = sizeof( buf );
@@ -723,81 +732,81 @@ int main( int argc, char *argv[] )
                              strlen( opt.user_name ) );
 
         if( ret != 0 ) {
-            printf( " failed\n  ! base64_encode returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! base64_encode returned %d\n\n", ret );
             goto exit;
         }
         len = sprintf( (char *) buf, "%s\r\n", base );
         ret = write_ssl_and_get_response( &ssl, buf, len );
         if( ret < 300 || ret > 399 )
         {
-            printf( " failed\n  ! server responded with %d\n\n", ret );
+            polarssl_printf( " failed\n  ! server responded with %d\n\n", ret );
             goto exit;
         }
 
-        printf(" ok\n" );
+        polarssl_printf(" ok\n" );
 
-        printf( "  > Write password to server: %s", opt.user_pwd );
+        polarssl_printf( "  > Write password to server: %s", opt.user_pwd );
         fflush( stdout );
 
         ret = base64_encode( base, &n, (const unsigned char *) opt.user_pwd,
                              strlen( opt.user_pwd ) );
 
         if( ret != 0 ) {
-            printf( " failed\n  ! base64_encode returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! base64_encode returned %d\n\n", ret );
             goto exit;
         }
         len = sprintf( (char *) buf, "%s\r\n", base );
         ret = write_ssl_and_get_response( &ssl, buf, len );
         if( ret < 200 || ret > 399 )
         {
-            printf( " failed\n  ! server responded with %d\n\n", ret );
+            polarssl_printf( " failed\n  ! server responded with %d\n\n", ret );
             goto exit;
         }
 
-        printf(" ok\n" );
+        polarssl_printf(" ok\n" );
     }
 #endif
 
-    printf( "  > Write MAIL FROM to server:" );
+    polarssl_printf( "  > Write MAIL FROM to server:" );
     fflush( stdout );
 
     len = sprintf( (char *) buf, "MAIL FROM:<%s>\r\n", opt.mail_from );
     ret = write_ssl_and_get_response( &ssl, buf, len );
     if( ret < 200 || ret > 299 )
     {
-        printf( " failed\n  ! server responded with %d\n\n", ret );
+        polarssl_printf( " failed\n  ! server responded with %d\n\n", ret );
         goto exit;
     }
 
-    printf(" ok\n" );
+    polarssl_printf(" ok\n" );
 
-    printf( "  > Write RCPT TO to server:" );
+    polarssl_printf( "  > Write RCPT TO to server:" );
     fflush( stdout );
 
     len = sprintf( (char *) buf, "RCPT TO:<%s>\r\n", opt.mail_to );
     ret = write_ssl_and_get_response( &ssl, buf, len );
     if( ret < 200 || ret > 299 )
     {
-        printf( " failed\n  ! server responded with %d\n\n", ret );
+        polarssl_printf( " failed\n  ! server responded with %d\n\n", ret );
         goto exit;
     }
 
-    printf(" ok\n" );
+    polarssl_printf(" ok\n" );
 
-    printf( "  > Write DATA to server:" );
+    polarssl_printf( "  > Write DATA to server:" );
     fflush( stdout );
 
     len = sprintf( (char *) buf, "DATA\r\n" );
     ret = write_ssl_and_get_response( &ssl, buf, len );
     if( ret < 300 || ret > 399 )
     {
-        printf( " failed\n  ! server responded with %d\n\n", ret );
+        polarssl_printf( " failed\n  ! server responded with %d\n\n", ret );
         goto exit;
     }
 
-    printf(" ok\n" );
+    polarssl_printf(" ok\n" );
 
-    printf( "  > Write content to server:" );
+    polarssl_printf( "  > Write content to server:" );
     fflush( stdout );
 
     len = sprintf( (char *) buf, "From: %s\r\nSubject: PolarSSL Test mail\r\n\r\n"
@@ -811,11 +820,11 @@ int main( int argc, char *argv[] )
     ret = write_ssl_and_get_response( &ssl, buf, len );
     if( ret < 200 || ret > 299 )
     {
-        printf( " failed\n  ! server responded with %d\n\n", ret );
+        polarssl_printf( " failed\n  ! server responded with %d\n\n", ret );
         goto exit;
     }
 
-    printf(" ok\n" );
+    polarssl_printf(" ok\n" );
 
     ssl_close_notify( &ssl );
 
@@ -831,7 +840,7 @@ exit:
     entropy_free( &entropy );
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/ssl/ssl_pthread_server.c
+++ b/programs/ssl/ssl_pthread_server.c
@@ -33,6 +33,7 @@
 #if defined(POLARSSL_PLATFORM_C)
 #include "polarssl/platform.h"
 #else
+#define polarssl_snprintf   snprintf
 #define polarssl_printf     printf
 #define polarssl_fprintf    fprintf
 #define polarssl_malloc     malloc
@@ -142,7 +143,7 @@ static void *handle_ssl_connection( void *data )
     memset( &ssl, 0, sizeof( ssl_context ) );
     memset( &ctr_drbg, 0, sizeof( ctr_drbg_context ) );
 
-    snprintf( pers, sizeof(pers), "SSL Pthread Thread %d", thread_id );
+    polarssl_snprintf( pers, sizeof(pers), "SSL Pthread Thread %d", thread_id );
     polarssl_printf( "  [ #%d ]  Client FD %d\n", thread_id, client_fd );
     polarssl_printf( "  [ #%d ]  Seeding the random number generator...\n", thread_id );
 

--- a/programs/ssl/ssl_pthread_server.c
+++ b/programs/ssl/ssl_pthread_server.c
@@ -30,6 +30,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #if defined(_WIN32)
 #include <windows.h>
 #endif
@@ -65,7 +74,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_CERTS_C and/or POLARSSL_ENTROPY_C "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_CERTS_C and/or POLARSSL_ENTROPY_C "
            "and/or POLARSSL_SSL_TLS_C and/or POLARSSL_SSL_SRV_C and/or "
            "POLARSSL_NET_C and/or POLARSSL_RSA_C and/or "
            "POLARSSL_CTR_DRBG_C and/or POLARSSL_X509_CRT_PARSE_C and/or "
@@ -89,7 +98,7 @@ static void my_mutexed_debug( void *ctx, int level, const char *str )
     polarssl_mutex_lock( &debug_mutex );
     if( level < DEBUG_LEVEL )
     {
-        fprintf( (FILE *) ctx, "%s", str );
+        polarssl_fprintf( (FILE *) ctx, "%s", str );
         fflush(  (FILE *) ctx  );
     }
     polarssl_mutex_unlock( &debug_mutex );
@@ -134,8 +143,8 @@ static void *handle_ssl_connection( void *data )
     memset( &ctr_drbg, 0, sizeof( ctr_drbg_context ) );
 
     snprintf( pers, sizeof(pers), "SSL Pthread Thread %d", thread_id );
-    printf( "  [ #%d ]  Client FD %d\n", thread_id, client_fd );
-    printf( "  [ #%d ]  Seeding the random number generator...\n", thread_id );
+    polarssl_printf( "  [ #%d ]  Client FD %d\n", thread_id, client_fd );
+    polarssl_printf( "  [ #%d ]  Seeding the random number generator...\n", thread_id );
 
     /* entropy_func() is thread-safe if POLARSSL_THREADING_C is set
      */
@@ -143,21 +152,21 @@ static void *handle_ssl_connection( void *data )
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        printf( "  [ #%d ]  failed: ctr_drbg_init returned -0x%04x\n",
+        polarssl_printf( "  [ #%d ]  failed: ctr_drbg_init returned -0x%04x\n",
                 thread_id, -ret );
         goto thread_exit;
     }
 
-    printf( "  [ #%d ]  ok\n", thread_id );
+    polarssl_printf( "  [ #%d ]  ok\n", thread_id );
 
     /*
      * 4. Setup stuff
      */
-    printf( "  [ #%d ]  Setting up the SSL data....\n", thread_id );
+    polarssl_printf( "  [ #%d ]  Setting up the SSL data....\n", thread_id );
 
     if( ( ret = ssl_init( &ssl ) ) != 0 )
     {
-        printf( "  [ #%d ]  failed: ssl_init returned -0x%04x\n",
+        polarssl_printf( "  [ #%d ]  failed: ssl_init returned -0x%04x\n",
                 thread_id, -ret );
         goto thread_exit;
     }
@@ -179,38 +188,38 @@ static void *handle_ssl_connection( void *data )
     ssl_set_ca_chain( &ssl, thread_info->ca_chain, NULL, NULL );
     if( ( ret = ssl_set_own_cert( &ssl, thread_info->server_cert, thread_info->server_key ) ) != 0 )
     {
-        printf( " failed\n  ! ssl_set_own_cert returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! ssl_set_own_cert returned %d\n\n", ret );
         goto thread_exit;
     }
 
-    printf( "  [ #%d ]  ok\n", thread_id );
+    polarssl_printf( "  [ #%d ]  ok\n", thread_id );
 
     ssl_set_bio( &ssl, net_recv, &client_fd,
                        net_send, &client_fd );
 
-    printf( "  [ #%d ]  ok\n", thread_id );
+    polarssl_printf( "  [ #%d ]  ok\n", thread_id );
 
     /*
      * 5. Handshake
      */
-    printf( "  [ #%d ]  Performing the SSL/TLS handshake\n", thread_id );
+    polarssl_printf( "  [ #%d ]  Performing the SSL/TLS handshake\n", thread_id );
 
     while( ( ret = ssl_handshake( &ssl ) ) != 0 )
     {
         if( ret != POLARSSL_ERR_NET_WANT_READ && ret != POLARSSL_ERR_NET_WANT_WRITE )
         {
-            printf( "  [ #%d ]  failed: ssl_handshake returned -0x%04x\n",
+            polarssl_printf( "  [ #%d ]  failed: ssl_handshake returned -0x%04x\n",
                     thread_id, -ret );
             goto thread_exit;
         }
     }
 
-    printf( "  [ #%d ]  ok\n", thread_id );
+    polarssl_printf( "  [ #%d ]  ok\n", thread_id );
 
     /*
      * 6. Read the HTTP Request
      */
-    printf( "  [ #%d ]  < Read from client\n", thread_id );
+    polarssl_printf( "  [ #%d ]  < Read from client\n", thread_id );
 
     do
     {
@@ -226,24 +235,24 @@ static void *handle_ssl_connection( void *data )
             switch( ret )
             {
                 case POLARSSL_ERR_SSL_PEER_CLOSE_NOTIFY:
-                    printf( "  [ #%d ]  connection was closed gracefully\n",
+                    polarssl_printf( "  [ #%d ]  connection was closed gracefully\n",
                             thread_id );
                     goto thread_exit;
 
                 case POLARSSL_ERR_NET_CONN_RESET:
-                    printf( "  [ #%d ]  connection was reset by peer\n",
+                    polarssl_printf( "  [ #%d ]  connection was reset by peer\n",
                             thread_id );
                     goto thread_exit;
 
                 default:
-                    printf( "  [ #%d ]  ssl_read returned -0x%04x\n",
+                    polarssl_printf( "  [ #%d ]  ssl_read returned -0x%04x\n",
                             thread_id, -ret );
                     goto thread_exit;
             }
         }
 
         len = ret;
-        printf( "  [ #%d ]  %d bytes read\n=====\n%s\n=====\n",
+        polarssl_printf( "  [ #%d ]  %d bytes read\n=====\n%s\n=====\n",
                 thread_id, len, (char *) buf );
 
         if( ret > 0 )
@@ -254,7 +263,7 @@ static void *handle_ssl_connection( void *data )
     /*
      * 7. Write the 200 Response
      */
-    printf( "  [ #%d ]  > Write to client:\n", thread_id );
+    polarssl_printf( "  [ #%d ]  > Write to client:\n", thread_id );
 
     len = sprintf( (char *) buf, HTTP_RESPONSE,
                    ssl_get_ciphersuite( &ssl ) );
@@ -263,37 +272,37 @@ static void *handle_ssl_connection( void *data )
     {
         if( ret == POLARSSL_ERR_NET_CONN_RESET )
         {
-            printf( "  [ #%d ]  failed: peer closed the connection\n",
+            polarssl_printf( "  [ #%d ]  failed: peer closed the connection\n",
                     thread_id );
             goto thread_exit;
         }
 
         if( ret != POLARSSL_ERR_NET_WANT_READ && ret != POLARSSL_ERR_NET_WANT_WRITE )
         {
-            printf( "  [ #%d ]  failed: ssl_write returned -0x%04x\n",
+            polarssl_printf( "  [ #%d ]  failed: ssl_write returned -0x%04x\n",
                     thread_id, ret );
             goto thread_exit;
         }
     }
 
     len = ret;
-    printf( "  [ #%d ]  %d bytes written\n=====\n%s\n=====\n",
+    polarssl_printf( "  [ #%d ]  %d bytes written\n=====\n%s\n=====\n",
             thread_id, len, (char *) buf );
 
-    printf( "  [ #%d ]  . Closing the connection...", thread_id );
+    polarssl_printf( "  [ #%d ]  . Closing the connection...", thread_id );
 
     while( ( ret = ssl_close_notify( &ssl ) ) < 0 )
     {
         if( ret != POLARSSL_ERR_NET_WANT_READ &&
             ret != POLARSSL_ERR_NET_WANT_WRITE )
         {
-            printf( "  [ #%d ]  failed: ssl_close_notify returned -0x%04x\n",
+            polarssl_printf( "  [ #%d ]  failed: ssl_close_notify returned -0x%04x\n",
                     thread_id, ret );
             goto thread_exit;
         }
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     ret = 0;
 
@@ -304,7 +313,7 @@ thread_exit:
     {
         char error_buf[100];
         polarssl_strerror( ret, error_buf, 100 );
-        printf("  [ #%d ]  Last error was: -0x%04x - %s\n\n",
+        polarssl_printf("  [ #%d ]  Last error was: -0x%04x - %s\n\n",
                thread_id, -ret, error_buf );
     }
 #endif
@@ -332,7 +341,7 @@ static int thread_create( int client_fd )
 
         if( threads[i].data.thread_complete == 1 )
         {
-            printf( "  [ main ]  Cleaning up thread %d\n", i );
+            polarssl_printf( "  [ main ]  Cleaning up thread %d\n", i );
             pthread_join(threads[i].thread, NULL );
             memset( &threads[i], 0, sizeof(pthread_info_t) );
             break;
@@ -398,7 +407,7 @@ int main( int argc, char *argv[] )
     /*
      * 1. Load the certificates and private RSA key
      */
-    printf( "\n  . Loading the server cert. and key..." );
+    polarssl_printf( "\n  . Loading the server cert. and key..." );
     fflush( stdout );
 
     x509_crt_init( &srvcert );
@@ -412,7 +421,7 @@ int main( int argc, char *argv[] )
                           strlen( test_srv_crt ) );
     if( ret != 0 )
     {
-        printf( " failed\n  !  x509_crt_parse returned %d\n\n", ret );
+        polarssl_printf( " failed\n  !  x509_crt_parse returned %d\n\n", ret );
         goto exit;
     }
 
@@ -420,7 +429,7 @@ int main( int argc, char *argv[] )
                           strlen( test_ca_list ) );
     if( ret != 0 )
     {
-        printf( " failed\n  !  x509_crt_parse returned %d\n\n", ret );
+        polarssl_printf( " failed\n  !  x509_crt_parse returned %d\n\n", ret );
         goto exit;
     }
 
@@ -429,7 +438,7 @@ int main( int argc, char *argv[] )
                          strlen( test_srv_key ), NULL, 0 );
     if( ret != 0 )
     {
-        printf( " failed\n  !  pk_parse_key returned %d\n\n", ret );
+        polarssl_printf( " failed\n  !  pk_parse_key returned %d\n\n", ret );
         goto exit;
     }
 
@@ -437,21 +446,21 @@ int main( int argc, char *argv[] )
     base_info.server_cert = &srvcert;
     base_info.server_key = &pkey;
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 2. Setup the listening TCP socket
      */
-    printf( "  . Bind on https://localhost:4433/ ..." );
+    polarssl_printf( "  . Bind on https://localhost:4433/ ..." );
     fflush( stdout );
 
     if( ( ret = net_bind( &listen_fd, NULL, 4433 ) ) != 0 )
     {
-        printf( " failed\n  ! net_bind returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! net_bind returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
 reset:
 #ifdef POLARSSL_ERROR_C
@@ -459,7 +468,7 @@ reset:
     {
         char error_buf[100];
         polarssl_strerror( ret, error_buf, 100 );
-        printf( "  [ main ]  Last error was: -0x%04x - %s\n", -ret, error_buf );
+        polarssl_printf( "  [ main ]  Last error was: -0x%04x - %s\n", -ret, error_buf );
     }
 #endif
 
@@ -468,20 +477,20 @@ reset:
      */
     client_fd = -1;
 
-    printf( "  [ main ]  Waiting for a remote connection\n" );
+    polarssl_printf( "  [ main ]  Waiting for a remote connection\n" );
 
     if( ( ret = net_accept( listen_fd, &client_fd, NULL ) ) != 0 )
     {
-        printf( "  [ main ] failed: net_accept returned -0x%04x\n", ret );
+        polarssl_printf( "  [ main ] failed: net_accept returned -0x%04x\n", ret );
         goto exit;
     }
 
-    printf( "  [ main ]  ok\n" );
-    printf( "  [ main ]  Creating a new thread\n" );
+    polarssl_printf( "  [ main ]  ok\n" );
+    polarssl_printf( "  [ main ]  Creating a new thread\n" );
 
     if( ( ret = thread_create( client_fd ) ) != 0 )
     {
-        printf( "  [ main ]  failed: thread_create returned %d\n", ret );
+        polarssl_printf( "  [ main ]  failed: thread_create returned %d\n", ret );
         net_close( client_fd );
         goto reset;
     }
@@ -504,7 +513,7 @@ exit:
 #endif
 
 #if defined(_WIN32)
-    printf( "  Press Enter to exit this program.\n" );
+    polarssl_printf( "  Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/ssl/ssl_server.c
+++ b/programs/ssl/ssl_server.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #if defined(_WIN32)
 #include <windows.h>
 #endif
@@ -60,7 +69,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_CERTS_C and/or POLARSSL_ENTROPY_C "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_CERTS_C and/or POLARSSL_ENTROPY_C "
            "and/or POLARSSL_SSL_TLS_C and/or POLARSSL_SSL_SRV_C and/or "
            "POLARSSL_NET_C and/or POLARSSL_RSA_C and/or "
            "POLARSSL_CTR_DRBG_C and/or POLARSSL_X509_CRT_PARSE_C "
@@ -80,7 +89,7 @@ static void my_debug( void *ctx, int level, const char *str )
 {
     ((void) level);
 
-    fprintf( (FILE *) ctx, "%s", str );
+    polarssl_fprintf( (FILE *) ctx, "%s", str );
     fflush(  (FILE *) ctx  );
 }
 
@@ -119,7 +128,7 @@ int main( int argc, char *argv[] )
     /*
      * 1. Load the certificates and private RSA key
      */
-    printf( "\n  . Loading the server cert. and key..." );
+    polarssl_printf( "\n  . Loading the server cert. and key..." );
     fflush( stdout );
 
     /*
@@ -131,7 +140,7 @@ int main( int argc, char *argv[] )
                           strlen( test_srv_crt ) );
     if( ret != 0 )
     {
-        printf( " failed\n  !  x509_crt_parse returned %d\n\n", ret );
+        polarssl_printf( " failed\n  !  x509_crt_parse returned %d\n\n", ret );
         goto exit;
     }
 
@@ -139,7 +148,7 @@ int main( int argc, char *argv[] )
                           strlen( test_ca_list ) );
     if( ret != 0 )
     {
-        printf( " failed\n  !  x509_crt_parse returned %d\n\n", ret );
+        polarssl_printf( " failed\n  !  x509_crt_parse returned %d\n\n", ret );
         goto exit;
     }
 
@@ -147,51 +156,51 @@ int main( int argc, char *argv[] )
                          strlen( test_srv_key ), NULL, 0 );
     if( ret != 0 )
     {
-        printf( " failed\n  !  pk_parse_key returned %d\n\n", ret );
+        polarssl_printf( " failed\n  !  pk_parse_key returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 2. Setup the listening TCP socket
      */
-    printf( "  . Bind on https://localhost:4433/ ..." );
+    polarssl_printf( "  . Bind on https://localhost:4433/ ..." );
     fflush( stdout );
 
     if( ( ret = net_bind( &listen_fd, NULL, 4433 ) ) != 0 )
     {
-        printf( " failed\n  ! net_bind returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! net_bind returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 3. Seed the RNG
      */
-    printf( "  . Seeding the random number generator..." );
+    polarssl_printf( "  . Seeding the random number generator..." );
     fflush( stdout );
 
     if( ( ret = ctr_drbg_init( &ctr_drbg, entropy_func, &entropy,
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
+        polarssl_printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 4. Setup stuff
      */
-    printf( "  . Setting up the SSL data...." );
+    polarssl_printf( "  . Setting up the SSL data...." );
     fflush( stdout );
 
     if( ( ret = ssl_init( &ssl ) ) != 0 )
     {
-        printf( " failed\n  ! ssl_init returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! ssl_init returned %d\n\n", ret );
         goto exit;
     }
 
@@ -209,11 +218,11 @@ int main( int argc, char *argv[] )
     ssl_set_ca_chain( &ssl, srvcert.next, NULL, NULL );
     if( ( ret = ssl_set_own_cert( &ssl, &srvcert, &pkey ) ) != 0 )
     {
-        printf( " failed\n  ! ssl_set_own_cert returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! ssl_set_own_cert returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
 reset:
 #ifdef POLARSSL_ERROR_C
@@ -221,7 +230,7 @@ reset:
     {
         char error_buf[100];
         polarssl_strerror( ret, error_buf, 100 );
-        printf("Last error was: %d - %s\n\n", ret, error_buf );
+        polarssl_printf("Last error was: %d - %s\n\n", ret, error_buf );
     }
 #endif
 
@@ -235,41 +244,41 @@ reset:
      */
     client_fd = -1;
 
-    printf( "  . Waiting for a remote connection ..." );
+    polarssl_printf( "  . Waiting for a remote connection ..." );
     fflush( stdout );
 
     if( ( ret = net_accept( listen_fd, &client_fd, NULL ) ) != 0 )
     {
-        printf( " failed\n  ! net_accept returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! net_accept returned %d\n\n", ret );
         goto exit;
     }
 
     ssl_set_bio( &ssl, net_recv, &client_fd,
                        net_send, &client_fd );
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 5. Handshake
      */
-    printf( "  . Performing the SSL/TLS handshake..." );
+    polarssl_printf( "  . Performing the SSL/TLS handshake..." );
     fflush( stdout );
 
     while( ( ret = ssl_handshake( &ssl ) ) != 0 )
     {
         if( ret != POLARSSL_ERR_NET_WANT_READ && ret != POLARSSL_ERR_NET_WANT_WRITE )
         {
-            printf( " failed\n  ! ssl_handshake returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_handshake returned %d\n\n", ret );
             goto reset;
         }
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 6. Read the HTTP Request
      */
-    printf( "  < Read from client:" );
+    polarssl_printf( "  < Read from client:" );
     fflush( stdout );
 
     do
@@ -286,15 +295,15 @@ reset:
             switch( ret )
             {
                 case POLARSSL_ERR_SSL_PEER_CLOSE_NOTIFY:
-                    printf( " connection was closed gracefully\n" );
+                    polarssl_printf( " connection was closed gracefully\n" );
                     break;
 
                 case POLARSSL_ERR_NET_CONN_RESET:
-                    printf( " connection was reset by peer\n" );
+                    polarssl_printf( " connection was reset by peer\n" );
                     break;
 
                 default:
-                    printf( " ssl_read returned -0x%x\n", -ret );
+                    polarssl_printf( " ssl_read returned -0x%x\n", -ret );
                     break;
             }
 
@@ -302,7 +311,7 @@ reset:
         }
 
         len = ret;
-        printf( " %d bytes read\n\n%s", len, (char *) buf );
+        polarssl_printf( " %d bytes read\n\n%s", len, (char *) buf );
 
         if( ret > 0 )
             break;
@@ -312,7 +321,7 @@ reset:
     /*
      * 7. Write the 200 Response
      */
-    printf( "  > Write to client:" );
+    polarssl_printf( "  > Write to client:" );
     fflush( stdout );
 
     len = sprintf( (char *) buf, HTTP_RESPONSE,
@@ -322,33 +331,33 @@ reset:
     {
         if( ret == POLARSSL_ERR_NET_CONN_RESET )
         {
-            printf( " failed\n  ! peer closed the connection\n\n" );
+            polarssl_printf( " failed\n  ! peer closed the connection\n\n" );
             goto reset;
         }
 
         if( ret != POLARSSL_ERR_NET_WANT_READ && ret != POLARSSL_ERR_NET_WANT_WRITE )
         {
-            printf( " failed\n  ! ssl_write returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_write returned %d\n\n", ret );
             goto exit;
         }
     }
 
     len = ret;
-    printf( " %d bytes written\n\n%s\n", len, (char *) buf );
+    polarssl_printf( " %d bytes written\n\n%s\n", len, (char *) buf );
 
-    printf( "  . Closing the connection..." );
+    polarssl_printf( "  . Closing the connection..." );
 
     while( ( ret = ssl_close_notify( &ssl ) ) < 0 )
     {
         if( ret != POLARSSL_ERR_NET_WANT_READ &&
             ret != POLARSSL_ERR_NET_WANT_WRITE )
         {
-            printf( " failed\n  ! ssl_close_notify returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_close_notify returned %d\n\n", ret );
             goto reset;
         }
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     ret = 0;
     goto reset;
@@ -360,7 +369,7 @@ exit:
     {
         char error_buf[100];
         polarssl_strerror( ret, error_buf, 100 );
-        printf("Last error was: %d - %s\n\n", ret, error_buf );
+        polarssl_printf("Last error was: %d - %s\n\n", ret, error_buf );
     }
 #endif
 
@@ -377,7 +386,7 @@ exit:
     entropy_free( &entropy );
 
 #if defined(_WIN32)
-    printf( "  Press Enter to exit this program.\n" );
+    polarssl_printf( "  Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #if !defined(POLARSSL_ENTROPY_C) ||  \
     !defined(POLARSSL_SSL_TLS_C) || !defined(POLARSSL_SSL_SRV_C) || \
     !defined(POLARSSL_NET_C) || !defined(POLARSSL_CTR_DRBG_C)
@@ -38,7 +47,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_ENTROPY_C and/or "
+    polarssl_printf("POLARSSL_ENTROPY_C and/or "
            "POLARSSL_SSL_TLS_C and/or POLARSSL_SSL_SRV_C and/or "
            "POLARSSL_NET_C and/or POLARSSL_CTR_DRBG_C not defined.\n");
     return( 0 );
@@ -47,13 +56,6 @@ int main( int argc, char *argv[] )
 
 #if defined(POLARSSL_SSL_SERVER_NAME_INDICATION) && defined(POLARSSL_FS_IO)
 #define POLARSSL_SNI
-#endif
-
-#if defined(POLARSSL_PLATFORM_C)
-#include "polarssl/platform.h"
-#else
-#define polarssl_malloc     malloc
-#define polarssl_free       free
 #endif
 
 #if defined(_WIN32)
@@ -182,7 +184,7 @@ static void my_debug( void *ctx, int level, const char *str )
 {
     ((void) level);
 
-    fprintf( (FILE *) ctx, "%s", str );
+    polarssl_fprintf( (FILE *) ctx, "%s", str );
     fflush(  (FILE *) ctx  );
 }
 
@@ -666,19 +668,19 @@ int main( int argc, char *argv[] )
         if( ret == 0 )
             ret = 1;
 
-        printf( USAGE );
+        polarssl_printf( USAGE );
 
         list = ssl_list_ciphersuites();
         while( *list )
         {
-            printf(" %-42s", ssl_get_ciphersuite_name( *list ) );
+            polarssl_printf(" %-42s", ssl_get_ciphersuite_name( *list ) );
             list++;
             if( !*list )
                 break;
-            printf(" %s\n", ssl_get_ciphersuite_name( *list ) );
+            polarssl_printf(" %s\n", ssl_get_ciphersuite_name( *list ) );
             list++;
         }
-        printf("\n");
+        polarssl_printf("\n");
         goto exit;
     }
 
@@ -924,14 +926,14 @@ int main( int argc, char *argv[] )
         if( opt.max_version != -1 &&
             ciphersuite_info->min_minor_ver > opt.max_version )
         {
-            printf("forced ciphersuite not allowed with this protocol version\n");
+            polarssl_printf("forced ciphersuite not allowed with this protocol version\n");
             ret = 2;
             goto usage;
         }
         if( opt.min_version != -1 &&
             ciphersuite_info->max_minor_ver < opt.min_version )
         {
-            printf("forced ciphersuite not allowed with this protocol version\n");
+            polarssl_printf("forced ciphersuite not allowed with this protocol version\n");
             ret = 2;
             goto usage;
         }
@@ -961,7 +963,7 @@ int main( int argc, char *argv[] )
 
         if( i != 4 )
         {
-            printf( "too few values for version_suites\n" );
+            polarssl_printf( "too few values for version_suites\n" );
             ret = 1;
             goto exit;
         }
@@ -975,7 +977,7 @@ int main( int argc, char *argv[] )
 
             if( version_suites[i][0] == 0 )
             {
-                printf( "unknown ciphersuite: '%s'\n", name[i] );
+                polarssl_printf( "unknown ciphersuite: '%s'\n", name[i] );
                 ret = 2;
                 goto usage;
             }
@@ -988,7 +990,7 @@ int main( int argc, char *argv[] )
      */
     if( unhexify( psk, opt.psk, &psk_len ) != 0 )
     {
-        printf( "pre-shared key not valid hex\n" );
+        polarssl_printf( "pre-shared key not valid hex\n" );
         goto exit;
     }
 
@@ -996,7 +998,7 @@ int main( int argc, char *argv[] )
     {
         if( ( psk_info = psk_parse( opt.psk_list ) ) == NULL )
         {
-            printf( "psk_list invalid" );
+            polarssl_printf( "psk_list invalid" );
             goto exit;
         }
     }
@@ -1025,7 +1027,7 @@ int main( int argc, char *argv[] )
     /*
      * 0. Initialize the RNG and the session data
      */
-    printf( "\n  . Seeding the random number generator..." );
+    polarssl_printf( "\n  . Seeding the random number generator..." );
     fflush( stdout );
 
     entropy_init( &entropy );
@@ -1033,17 +1035,17 @@ int main( int argc, char *argv[] )
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        printf( " failed\n  ! ctr_drbg_init returned -0x%x\n", -ret );
+        polarssl_printf( " failed\n  ! ctr_drbg_init returned -0x%x\n", -ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
 #if defined(POLARSSL_X509_CRT_PARSE_C)
     /*
      * 1.1. Load the trusted CA
      */
-    printf( "  . Loading the CA root certificate ..." );
+    polarssl_printf( "  . Loading the CA root certificate ..." );
     fflush( stdout );
 
 #if defined(POLARSSL_FS_IO)
@@ -1065,21 +1067,21 @@ int main( int argc, char *argv[] )
 #else
     {
         ret = 1;
-        printf("POLARSSL_CERTS_C not defined.");
+        polarssl_printf("POLARSSL_CERTS_C not defined.");
     }
 #endif
     if( ret < 0 )
     {
-        printf( " failed\n  !  x509_crt_parse returned -0x%x\n\n", -ret );
+        polarssl_printf( " failed\n  !  x509_crt_parse returned -0x%x\n\n", -ret );
         goto exit;
     }
 
-    printf( " ok (%d skipped)\n", ret );
+    polarssl_printf( " ok (%d skipped)\n", ret );
 
     /*
      * 1.2. Load own certificate and private key
      */
-    printf( "  . Loading the server cert. and key..." );
+    polarssl_printf( "  . Loading the server cert. and key..." );
     fflush( stdout );
 
 #if defined(POLARSSL_FS_IO)
@@ -1088,7 +1090,7 @@ int main( int argc, char *argv[] )
         key_cert_init++;
         if( ( ret = x509_crt_parse_file( &srvcert, opt.crt_file ) ) != 0 )
         {
-            printf( " failed\n  !  x509_crt_parse_file returned -0x%x\n\n",
+            polarssl_printf( " failed\n  !  x509_crt_parse_file returned -0x%x\n\n",
                     -ret );
             goto exit;
         }
@@ -1098,13 +1100,13 @@ int main( int argc, char *argv[] )
         key_cert_init++;
         if( ( ret = pk_parse_keyfile( &pkey, opt.key_file, "" ) ) != 0 )
         {
-            printf( " failed\n  !  pk_parse_keyfile returned -0x%x\n\n", -ret );
+            polarssl_printf( " failed\n  !  pk_parse_keyfile returned -0x%x\n\n", -ret );
             goto exit;
         }
     }
     if( key_cert_init == 1 )
     {
-        printf( " failed\n  !  crt_file without key_file or vice-versa\n\n" );
+        polarssl_printf( " failed\n  !  crt_file without key_file or vice-versa\n\n" );
         goto exit;
     }
 
@@ -1113,7 +1115,7 @@ int main( int argc, char *argv[] )
         key_cert_init2++;
         if( ( ret = x509_crt_parse_file( &srvcert2, opt.crt_file2 ) ) != 0 )
         {
-            printf( " failed\n  !  x509_crt_parse_file(2) returned -0x%x\n\n",
+            polarssl_printf( " failed\n  !  x509_crt_parse_file(2) returned -0x%x\n\n",
                     -ret );
             goto exit;
         }
@@ -1123,14 +1125,14 @@ int main( int argc, char *argv[] )
         key_cert_init2++;
         if( ( ret = pk_parse_keyfile( &pkey2, opt.key_file2, "" ) ) != 0 )
         {
-            printf( " failed\n  !  pk_parse_keyfile(2) returned -0x%x\n\n",
+            polarssl_printf( " failed\n  !  pk_parse_keyfile(2) returned -0x%x\n\n",
                     -ret );
             goto exit;
         }
     }
     if( key_cert_init2 == 1 )
     {
-        printf( " failed\n  !  crt_file2 without key_file2 or vice-versa\n\n" );
+        polarssl_printf( " failed\n  !  crt_file2 without key_file2 or vice-versa\n\n" );
         goto exit;
     }
 #endif
@@ -1142,7 +1144,7 @@ int main( int argc, char *argv[] )
         strcmp( opt.key_file2, "none" ) != 0 )
     {
 #if !defined(POLARSSL_CERTS_C)
-        printf( "Not certificated or key provided, and \n"
+        polarssl_printf( "Not certificated or key provided, and \n"
                 "POLARSSL_CERTS_C not defined!\n" );
         goto exit;
 #else
@@ -1151,14 +1153,14 @@ int main( int argc, char *argv[] )
                                     (const unsigned char *) test_srv_crt_rsa,
                                     strlen( test_srv_crt_rsa ) ) ) != 0 )
         {
-            printf( " failed\n  !  x509_crt_parse returned -0x%x\n\n", -ret );
+            polarssl_printf( " failed\n  !  x509_crt_parse returned -0x%x\n\n", -ret );
             goto exit;
         }
         if( ( ret = pk_parse_key( &pkey,
                                   (const unsigned char *) test_srv_key_rsa,
                                   strlen( test_srv_key_rsa ), NULL, 0 ) ) != 0 )
         {
-            printf( " failed\n  !  pk_parse_key returned -0x%x\n\n", -ret );
+            polarssl_printf( " failed\n  !  pk_parse_key returned -0x%x\n\n", -ret );
             goto exit;
         }
         key_cert_init = 2;
@@ -1168,14 +1170,14 @@ int main( int argc, char *argv[] )
                                     (const unsigned char *) test_srv_crt_ec,
                                     strlen( test_srv_crt_ec ) ) ) != 0 )
         {
-            printf( " failed\n  !  x509_crt_parse2 returned -0x%x\n\n", -ret );
+            polarssl_printf( " failed\n  !  x509_crt_parse2 returned -0x%x\n\n", -ret );
             goto exit;
         }
         if( ( ret = pk_parse_key( &pkey2,
                                   (const unsigned char *) test_srv_key_ec,
                                   strlen( test_srv_key_ec ), NULL, 0 ) ) != 0 )
         {
-            printf( " failed\n  !  pk_parse_key2 returned -0x%x\n\n", -ret );
+            polarssl_printf( " failed\n  !  pk_parse_key2 returned -0x%x\n\n", -ret );
             goto exit;
         }
         key_cert_init2 = 2;
@@ -1183,66 +1185,66 @@ int main( int argc, char *argv[] )
 #endif /* POLARSSL_CERTS_C */
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 #endif /* POLARSSL_X509_CRT_PARSE_C */
 
 #if defined(POLARSSL_DHM_C) && defined(POLARSSL_FS_IO)
     if( opt.dhm_file != NULL )
     {
-        printf( "  . Loading DHM parameters..." );
+        polarssl_printf( "  . Loading DHM parameters..." );
         fflush( stdout );
 
         if( ( ret = dhm_parse_dhmfile( &dhm, opt.dhm_file ) ) != 0 )
         {
-            printf( " failed\n  ! dhm_parse_dhmfile returned -0x%04X\n\n",
+            polarssl_printf( " failed\n  ! dhm_parse_dhmfile returned -0x%04X\n\n",
                      -ret );
             goto exit;
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
     }
 #endif
 
 #if defined(POLARSSL_SNI)
     if( opt.sni != NULL )
     {
-        printf( "  . Setting up SNI information..." );
+        polarssl_printf( "  . Setting up SNI information..." );
         fflush( stdout );
 
         if( ( sni_info = sni_parse( opt.sni ) ) == NULL )
         {
-            printf( " failed\n" );
+            polarssl_printf( " failed\n" );
             goto exit;
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
     }
 #endif /* POLARSSL_SNI */
 
     /*
      * 2. Setup the listening TCP socket
      */
-    printf( "  . Bind on tcp://localhost:%-4d/ ...", opt.server_port );
+    polarssl_printf( "  . Bind on tcp://localhost:%-4d/ ...", opt.server_port );
     fflush( stdout );
 
     if( ( ret = net_bind( &listen_fd, opt.server_addr,
                                       opt.server_port ) ) != 0 )
     {
-        printf( " failed\n  ! net_bind returned -0x%x\n\n", -ret );
+        polarssl_printf( " failed\n  ! net_bind returned -0x%x\n\n", -ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 3. Setup stuff
      */
-    printf( "  . Setting up the SSL/TLS structure..." );
+    polarssl_printf( "  . Setting up the SSL/TLS structure..." );
     fflush( stdout );
 
     if( ( ret = ssl_init( &ssl ) ) != 0 )
     {
-        printf( " failed\n  ! ssl_init returned -0x%x\n\n", -ret );
+        polarssl_printf( " failed\n  ! ssl_init returned -0x%x\n\n", -ret );
         goto exit;
     }
 
@@ -1252,7 +1254,7 @@ int main( int argc, char *argv[] )
 #if defined(POLARSSL_SSL_MAX_FRAGMENT_LENGTH)
     if( ( ret = ssl_set_max_frag_len( &ssl, opt.mfl_code ) ) != 0 )
     {
-        printf( " failed\n  ! ssl_set_max_frag_len returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! ssl_set_max_frag_len returned %d\n\n", ret );
         goto exit;
     };
 #endif
@@ -1261,7 +1263,7 @@ int main( int argc, char *argv[] )
     if( opt.alpn_string != NULL )
         if( ( ret = ssl_set_alpn_protocols( &ssl, alpn_list ) ) != 0 )
         {
-            printf( " failed\n  ! ssl_set_alpn_protocols returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_set_alpn_protocols returned %d\n\n", ret );
             goto exit;
         }
 #endif
@@ -1283,7 +1285,7 @@ int main( int argc, char *argv[] )
 #if defined(POLARSSL_SSL_SESSION_TICKETS)
     if( ( ret = ssl_set_session_tickets( &ssl, opt.tickets ) ) != 0 )
     {
-        printf( " failed\n  ! ssl_set_session_tickets returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! ssl_set_session_tickets returned %d\n\n", ret );
         goto exit;
     }
 
@@ -1324,13 +1326,13 @@ int main( int argc, char *argv[] )
     if( key_cert_init )
         if( ( ret = ssl_set_own_cert( &ssl, &srvcert, &pkey ) ) != 0 )
         {
-            printf( " failed\n  ! ssl_set_own_cert returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_set_own_cert returned %d\n\n", ret );
             goto exit;
         }
     if( key_cert_init2 )
         if( ( ret = ssl_set_own_cert( &ssl, &srvcert2, &pkey2 ) ) != 0 )
         {
-            printf( " failed\n  ! ssl_set_own_cert returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_set_own_cert returned %d\n\n", ret );
             goto exit;
         }
 #endif
@@ -1348,7 +1350,7 @@ int main( int argc, char *argv[] )
                            strlen( opt.psk_identity ) );
         if( ret != 0 )
         {
-            printf( "  failed\n  ssl_set_psk returned -0x%04X\n\n", - ret );
+            polarssl_printf( "  failed\n  ssl_set_psk returned -0x%04X\n\n", - ret );
             goto exit;
         }
     }
@@ -1371,7 +1373,7 @@ int main( int argc, char *argv[] )
 
     if( ret != 0 )
     {
-        printf( "  failed\n  ssl_set_dh_param returned -0x%04X\n\n", - ret );
+        polarssl_printf( "  failed\n  ssl_set_dh_param returned -0x%04X\n\n", - ret );
         goto exit;
     }
 #endif
@@ -1382,7 +1384,7 @@ int main( int argc, char *argv[] )
     if( opt.max_version != -1 )
         ssl_set_max_version( &ssl, SSL_MAJOR_VERSION_3, opt.max_version );
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
 reset:
 #ifdef POLARSSL_ERROR_C
@@ -1390,7 +1392,7 @@ reset:
     {
         char error_buf[100];
         polarssl_strerror( ret, error_buf, 100 );
-        printf("Last error was: %d - %s\n\n", ret, error_buf );
+        polarssl_printf("Last error was: %d - %s\n\n", ret, error_buf );
     }
 #endif
 
@@ -1404,7 +1406,7 @@ reset:
      */
     client_fd = -1;
 
-    printf( "  . Waiting for a remote connection ..." );
+    polarssl_printf( "  . Waiting for a remote connection ..." );
     fflush( stdout );
 
     if( ( ret = net_accept( listen_fd, &client_fd, NULL ) ) != 0 )
@@ -1412,13 +1414,13 @@ reset:
 #if !defined(_WIN32)
         if( received_sigterm )
         {
-            printf( " interrupted by SIGTERM\n" );
+            polarssl_printf( " interrupted by SIGTERM\n" );
             ret = 0;
             goto exit;
         }
 #endif
 
-        printf( " failed\n  ! net_accept returned -0x%x\n\n", -ret );
+        polarssl_printf( " failed\n  ! net_accept returned -0x%x\n\n", -ret );
         goto exit;
     }
 
@@ -1428,7 +1430,7 @@ reset:
         ret = net_set_block( client_fd );
     if( ret != 0 )
     {
-        printf( " failed\n  ! net_set_(non)block() returned -0x%x\n\n", -ret );
+        polarssl_printf( " failed\n  ! net_set_(non)block() returned -0x%x\n\n", -ret );
         goto exit;
     }
 
@@ -1437,31 +1439,31 @@ reset:
     else
         ssl_set_bio( &ssl, net_recv, &client_fd, net_send, &client_fd );
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 4. Handshake
      */
-    printf( "  . Performing the SSL/TLS handshake..." );
+    polarssl_printf( "  . Performing the SSL/TLS handshake..." );
     fflush( stdout );
 
     while( ( ret = ssl_handshake( &ssl ) ) != 0 )
     {
         if( ret != POLARSSL_ERR_NET_WANT_READ && ret != POLARSSL_ERR_NET_WANT_WRITE )
         {
-            printf( " failed\n  ! ssl_handshake returned -0x%x\n\n", -ret );
+            polarssl_printf( " failed\n  ! ssl_handshake returned -0x%x\n\n", -ret );
             goto reset;
         }
     }
 
-    printf( " ok\n    [ Protocol is %s ]\n    [ Ciphersuite is %s ]\n",
+    polarssl_printf( " ok\n    [ Protocol is %s ]\n    [ Ciphersuite is %s ]\n",
             ssl_get_version( &ssl ), ssl_get_ciphersuite( &ssl ) );
 
 #if defined(POLARSSL_SSL_ALPN)
     if( opt.alpn_string != NULL )
     {
         const char *alp = ssl_get_alpn_protocol( &ssl );
-        printf( "    [ Application Layer Protocol is %s ]\n",
+        polarssl_printf( "    [ Application Layer Protocol is %s ]\n",
                 alp ? alp : "(none)" );
     }
 #endif
@@ -1470,35 +1472,35 @@ reset:
     /*
      * 5. Verify the server certificate
      */
-    printf( "  . Verifying peer X.509 certificate..." );
+    polarssl_printf( "  . Verifying peer X.509 certificate..." );
 
     if( ( ret = ssl_get_verify_result( &ssl ) ) != 0 )
     {
-        printf( " failed\n" );
+        polarssl_printf( " failed\n" );
 
         if( !ssl_get_peer_cert( &ssl ) )
-            printf( "  ! no client certificate sent\n" );
+            polarssl_printf( "  ! no client certificate sent\n" );
 
         if( ( ret & BADCERT_EXPIRED ) != 0 )
-            printf( "  ! client certificate has expired\n" );
+            polarssl_printf( "  ! client certificate has expired\n" );
 
         if( ( ret & BADCERT_REVOKED ) != 0 )
-            printf( "  ! client certificate has been revoked\n" );
+            polarssl_printf( "  ! client certificate has been revoked\n" );
 
         if( ( ret & BADCERT_NOT_TRUSTED ) != 0 )
-            printf( "  ! self-signed or not signed by a trusted CA\n" );
+            polarssl_printf( "  ! self-signed or not signed by a trusted CA\n" );
 
-        printf( "\n" );
+        polarssl_printf( "\n" );
     }
     else
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
 
     if( ssl_get_peer_cert( &ssl ) )
     {
-        printf( "  . Peer certificate information    ...\n" );
+        polarssl_printf( "  . Peer certificate information    ...\n" );
         x509_crt_info( (char *) buf, sizeof( buf ) - 1, "      ",
                        ssl_get_peer_cert( &ssl ) );
-        printf( "%s\n", buf );
+        polarssl_printf( "%s\n", buf );
     }
 #endif /* POLARSSL_X509_CRT_PARSE_C */
 
@@ -1507,7 +1509,7 @@ data_exchange:
     /*
      * 6. Read the HTTP Request
      */
-    printf( "  < Read from client:" );
+    polarssl_printf( "  < Read from client:" );
     fflush( stdout );
 
     do
@@ -1526,17 +1528,17 @@ data_exchange:
             switch( ret )
             {
                 case POLARSSL_ERR_SSL_PEER_CLOSE_NOTIFY:
-                    printf( " connection was closed gracefully\n" );
+                    polarssl_printf( " connection was closed gracefully\n" );
                     goto close_notify;
 
                 case 0:
                 case POLARSSL_ERR_NET_CONN_RESET:
-                    printf( " connection was reset by peer\n" );
+                    polarssl_printf( " connection was reset by peer\n" );
                     ret = POLARSSL_ERR_NET_CONN_RESET;
                     goto reset;
 
                 default:
-                    printf( " ssl_read returned -0x%x\n", -ret );
+                    polarssl_printf( " ssl_read returned -0x%x\n", -ret );
                     goto reset;
             }
         }
@@ -1545,7 +1547,7 @@ data_exchange:
         {
             len = ret;
             buf[len] = '\0';
-            printf( " %d bytes read\n\n%s\n", len, (char *) buf );
+            polarssl_printf( " %d bytes read\n\n%s\n", len, (char *) buf );
 
             /* End of message should be detected according to the syntax of the
              * application protocol (eg HTTP), just use a dummy test here. */
@@ -1563,7 +1565,7 @@ data_exchange:
             larger_buf = polarssl_malloc( ori_len + extra_len + 1 );
             if( larger_buf == NULL )
             {
-                printf( "  ! memory allocation failed\n" );
+                polarssl_printf( "  ! memory allocation failed\n" );
                 ret = 1;
                 goto reset;
             }
@@ -1576,13 +1578,13 @@ data_exchange:
             if( ret != extra_len ||
                 ssl_get_bytes_avail( &ssl ) != 0 )
             {
-                printf( "  ! ssl_read failed on cached data\n" );
+                polarssl_printf( "  ! ssl_read failed on cached data\n" );
                 ret = 1;
                 goto reset;
             }
 
             larger_buf[ori_len + extra_len] = '\0';
-            printf( " %u bytes read (%u + %u)\n\n%s\n",
+            polarssl_printf( " %u bytes read (%u + %u)\n\n%s\n",
                     ori_len + extra_len, ori_len, extra_len,
                     (char *) larger_buf );
 
@@ -1608,7 +1610,7 @@ data_exchange:
      */
     if( opt.renegotiate && exchanges > 1 )
     {
-        printf( "  . Requestion renegotiation..." );
+        polarssl_printf( "  . Requestion renegotiation..." );
         fflush( stdout );
 
         while( ( ret = ssl_renegotiate( &ssl ) ) != 0 )
@@ -1616,18 +1618,18 @@ data_exchange:
             if( ret != POLARSSL_ERR_NET_WANT_READ &&
                 ret != POLARSSL_ERR_NET_WANT_WRITE )
             {
-                printf( " failed\n  ! ssl_renegotiate returned %d\n\n", ret );
+                polarssl_printf( " failed\n  ! ssl_renegotiate returned %d\n\n", ret );
                 goto reset;
             }
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
     }
 
     /*
      * 7. Write the 200 Response
      */
-    printf( "  > Write to client:" );
+    polarssl_printf( "  > Write to client:" );
     fflush( stdout );
 
     len = sprintf( (char *) buf, HTTP_RESPONSE,
@@ -1639,20 +1641,20 @@ data_exchange:
         {
             if( ret == POLARSSL_ERR_NET_CONN_RESET )
             {
-                printf( " failed\n  ! peer closed the connection\n\n" );
+                polarssl_printf( " failed\n  ! peer closed the connection\n\n" );
                 goto reset;
             }
 
             if( ret != POLARSSL_ERR_NET_WANT_READ && ret != POLARSSL_ERR_NET_WANT_WRITE )
             {
-                printf( " failed\n  ! ssl_write returned %d\n\n", ret );
+                polarssl_printf( " failed\n  ! ssl_write returned %d\n\n", ret );
                 goto reset;
             }
         }
     }
 
     buf[written] = '\0';
-    printf( " %d bytes written in %d fragments\n\n%s\n", written, frags, (char *) buf );
+    polarssl_printf( " %d bytes written in %d fragments\n\n%s\n", written, frags, (char *) buf );
 
 
     /*
@@ -1665,13 +1667,13 @@ data_exchange:
      * 8. Done, cleanly close the connection
      */
 close_notify:
-    printf( "  . Closing the connection..." );
+    polarssl_printf( "  . Closing the connection..." );
 
     while( ( ret = ssl_close_notify( &ssl ) ) < 0 )
     {
         if( ret == POLARSSL_ERR_NET_CONN_RESET )
         {
-            printf( " ok (already closed by peer)\n" );
+            polarssl_printf( " ok (already closed by peer)\n" );
             ret = 0;
             goto reset;
         }
@@ -1679,12 +1681,12 @@ close_notify:
         if( ret != POLARSSL_ERR_NET_WANT_READ &&
             ret != POLARSSL_ERR_NET_WANT_WRITE )
         {
-            printf( " failed\n  ! ssl_close_notify returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_close_notify returned %d\n\n", ret );
             goto reset;
         }
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
     goto reset;
 
     /*
@@ -1696,7 +1698,7 @@ exit:
     {
         char error_buf[100];
         polarssl_strerror( ret, error_buf, 100 );
-        printf("Last error was: -0x%X - %s\n\n", -ret, error_buf );
+        polarssl_printf("Last error was: -0x%X - %s\n\n", -ret, error_buf );
     }
 #endif
 
@@ -1739,7 +1741,7 @@ exit:
 #endif
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -37,6 +37,7 @@
 #define polarssl_fprintf    fprintf
 #define polarssl_malloc     malloc
 #define polarssl_free       free
+#define polarssl_exit       exit
 #endif
 
 #include <string.h>
@@ -434,17 +435,17 @@ int main( int argc, char *argv[] )
         ctr_drbg_context ctr_drbg;
 
         if( ctr_drbg_init( &ctr_drbg, myrand, NULL, NULL, 0 ) != 0 )
-            exit(1);
+            polarssl_exit(1);
         TIME_AND_TSC( "CTR_DRBG (NOPR)",
                 if( ctr_drbg_random( &ctr_drbg, buf, BUFSIZE ) != 0 )
-                exit(1) );
+                polarssl_exit(1) );
 
         if( ctr_drbg_init( &ctr_drbg, myrand, NULL, NULL, 0 ) != 0 )
-            exit(1);
+            polarssl_exit(1);
         ctr_drbg_set_prediction_resistance( &ctr_drbg, CTR_DRBG_PR_ON );
         TIME_AND_TSC( "CTR_DRBG (PR)",
                 if( ctr_drbg_random( &ctr_drbg, buf, BUFSIZE ) != 0 )
-                exit(1) );
+                polarssl_exit(1) );
         ctr_drbg_free( &ctr_drbg );
     }
 #endif
@@ -457,43 +458,43 @@ int main( int argc, char *argv[] )
 
 #if defined(POLARSSL_SHA1_C)
         if( ( md_info = md_info_from_type( POLARSSL_MD_SHA1 ) ) == NULL )
-            exit(1);
+            polarssl_exit(1);
 
         if( hmac_drbg_init( &hmac_drbg, md_info, myrand, NULL, NULL, 0 ) != 0 )
-            exit(1);
+            polarssl_exit(1);
         TIME_AND_TSC( "HMAC_DRBG SHA-1 (NOPR)",
                 if( hmac_drbg_random( &hmac_drbg, buf, BUFSIZE ) != 0 )
-                exit(1) );
+                polarssl_exit(1) );
         hmac_drbg_free( &hmac_drbg );
 
         if( hmac_drbg_init( &hmac_drbg, md_info, myrand, NULL, NULL, 0 ) != 0 )
-            exit(1);
+            polarssl_exit(1);
         hmac_drbg_set_prediction_resistance( &hmac_drbg,
                                              POLARSSL_HMAC_DRBG_PR_ON );
         TIME_AND_TSC( "HMAC_DRBG SHA-1 (PR)",
                 if( hmac_drbg_random( &hmac_drbg, buf, BUFSIZE ) != 0 )
-                exit(1) );
+                polarssl_exit(1) );
         hmac_drbg_free( &hmac_drbg );
 #endif
 
 #if defined(POLARSSL_SHA256_C)
         if( ( md_info = md_info_from_type( POLARSSL_MD_SHA256 ) ) == NULL )
-            exit(1);
+            polarssl_exit(1);
 
         if( hmac_drbg_init( &hmac_drbg, md_info, myrand, NULL, NULL, 0 ) != 0 )
-            exit(1);
+            polarssl_exit(1);
         TIME_AND_TSC( "HMAC_DRBG SHA-256 (NOPR)",
                 if( hmac_drbg_random( &hmac_drbg, buf, BUFSIZE ) != 0 )
-                exit(1) );
+                polarssl_exit(1) );
         hmac_drbg_free( &hmac_drbg );
 
         if( hmac_drbg_init( &hmac_drbg, md_info, myrand, NULL, NULL, 0 ) != 0 )
-            exit(1);
+            polarssl_exit(1);
         hmac_drbg_set_prediction_resistance( &hmac_drbg,
                                              POLARSSL_HMAC_DRBG_PR_ON );
         TIME_AND_TSC( "HMAC_DRBG SHA-256 (PR)",
                 if( hmac_drbg_random( &hmac_drbg, buf, BUFSIZE ) != 0 )
-                exit(1) );
+                polarssl_exit(1) );
         hmac_drbg_free( &hmac_drbg );
 #endif
     }
@@ -548,13 +549,13 @@ int main( int argc, char *argv[] )
             if( mpi_read_string( &dhm.P, 16, dhm_P[i] ) != 0 ||
                 mpi_read_string( &dhm.G, 16, dhm_G[i] ) != 0 )
             {
-                exit( 1 );
+                polarssl_exit( 1 );
             }
 
             dhm.len = mpi_size( &dhm.P );
             dhm_make_public( &dhm, (int) dhm.len, buf, dhm.len, myrand, NULL );
             if( mpi_copy( &dhm.GY, &dhm.GX ) != 0 )
-                exit( 1 );
+                polarssl_exit( 1 );
 
             polarssl_snprintf( title, sizeof( title ), "DHE-%d", dhm_sizes[i] );
             TIME_PUBLIC( title, "handshake",
@@ -589,7 +590,7 @@ int main( int argc, char *argv[] )
             ecdsa_init( &ecdsa );
 
             if( ecdsa_genkey( &ecdsa, curve_info->grp_id, myrand, NULL ) != 0 )
-                exit( 1 );
+                polarssl_exit( 1 );
 
             polarssl_snprintf( title, sizeof( title ), "ECDSA-%s",
                                               curve_info->name );
@@ -624,7 +625,7 @@ int main( int argc, char *argv[] )
                                   myrand, NULL ) != 0 ||
                 ecp_copy( &ecdh.Qp, &ecdh.Q ) != 0 )
             {
-                exit( 1 );
+                polarssl_exit( 1 );
             }
 
             polarssl_snprintf( title, sizeof( title ), "ECDHE-%s",

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -32,6 +32,7 @@
 #if defined(POLARSSL_PLATFORM_C)
 #include "polarssl/platform.h"
 #else
+#define polarssl_snprintf   snprintf
 #define polarssl_printf     printf
 #define polarssl_fprintf    fprintf
 #define polarssl_malloc     malloc
@@ -319,7 +320,7 @@ int main( int argc, char *argv[] )
         aes_init( &aes );
         for( keysize = 128; keysize <= 256; keysize += 64 )
         {
-            snprintf( title, sizeof( title ), "AES-CBC-%d", keysize );
+            polarssl_snprintf( title, sizeof( title ), "AES-CBC-%d", keysize );
 
             memset( buf, 0, sizeof( buf ) );
             memset( tmp, 0, sizeof( tmp ) );
@@ -337,7 +338,7 @@ int main( int argc, char *argv[] )
         gcm_context gcm;
         for( keysize = 128; keysize <= 256; keysize += 64 )
         {
-            snprintf( title, sizeof( title ), "AES-GCM-%d", keysize );
+            polarssl_snprintf( title, sizeof( title ), "AES-GCM-%d", keysize );
 
             memset( buf, 0, sizeof( buf ) );
             memset( tmp, 0, sizeof( tmp ) );
@@ -357,7 +358,7 @@ int main( int argc, char *argv[] )
         ccm_context ccm;
         for( keysize = 128; keysize <= 256; keysize += 64 )
         {
-            snprintf( title, sizeof( title ), "AES-CCM-%d", keysize );
+            polarssl_snprintf( title, sizeof( title ), "AES-CCM-%d", keysize );
 
             memset( buf, 0, sizeof( buf ) );
             memset( tmp, 0, sizeof( tmp ) );
@@ -380,7 +381,7 @@ int main( int argc, char *argv[] )
         camellia_init( &camellia );
         for( keysize = 128; keysize <= 256; keysize += 64 )
         {
-            snprintf( title, sizeof( title ), "CAMELLIA-CBC-%d", keysize );
+            polarssl_snprintf( title, sizeof( title ), "CAMELLIA-CBC-%d", keysize );
 
             memset( buf, 0, sizeof( buf ) );
             memset( tmp, 0, sizeof( tmp ) );
@@ -402,7 +403,7 @@ int main( int argc, char *argv[] )
 
         for( keysize = 128; keysize <= 256; keysize += 64 )
         {
-            snprintf( title, sizeof( title ), "BLOWFISH-CBC-%d", keysize );
+            polarssl_snprintf( title, sizeof( title ), "BLOWFISH-CBC-%d", keysize );
 
             memset( buf, 0, sizeof( buf ) );
             memset( tmp, 0, sizeof( tmp ) );
@@ -504,7 +505,7 @@ int main( int argc, char *argv[] )
         rsa_context rsa;
         for( keysize = 1024; keysize <= 4096; keysize *= 2 )
         {
-            snprintf( title, sizeof( title ), "RSA-%d", keysize );
+            polarssl_snprintf( title, sizeof( title ), "RSA-%d", keysize );
 
             rsa_init( &rsa, RSA_PKCS_V15, 0 );
             rsa_gen_key( &rsa, myrand, NULL, keysize, 65537 );
@@ -555,14 +556,14 @@ int main( int argc, char *argv[] )
             if( mpi_copy( &dhm.GY, &dhm.GX ) != 0 )
                 exit( 1 );
 
-            snprintf( title, sizeof( title ), "DHE-%d", dhm_sizes[i] );
+            polarssl_snprintf( title, sizeof( title ), "DHE-%d", dhm_sizes[i] );
             TIME_PUBLIC( title, "handshake",
                     olen = sizeof( buf );
                     ret |= dhm_make_public( &dhm, (int) dhm.len, buf, dhm.len,
                                             myrand, NULL );
                     ret |= dhm_calc_secret( &dhm, buf, &olen, myrand, NULL ) );
 
-            snprintf( title, sizeof( title ), "DH-%d", dhm_sizes[i] );
+            polarssl_snprintf( title, sizeof( title ), "DH-%d", dhm_sizes[i] );
             TIME_PUBLIC( title, "handshake",
                     olen = sizeof( buf );
                     ret |= dhm_calc_secret( &dhm, buf, &olen, myrand, NULL ) );
@@ -590,7 +591,7 @@ int main( int argc, char *argv[] )
             if( ecdsa_genkey( &ecdsa, curve_info->grp_id, myrand, NULL ) != 0 )
                 exit( 1 );
 
-            snprintf( title, sizeof( title ), "ECDSA-%s",
+            polarssl_snprintf( title, sizeof( title ), "ECDSA-%s",
                                               curve_info->name );
             TIME_PUBLIC( title, "sign",
                     ret = ecdsa_write_signature( &ecdsa, buf, curve_info->size,
@@ -626,7 +627,7 @@ int main( int argc, char *argv[] )
                 exit( 1 );
             }
 
-            snprintf( title, sizeof( title ), "ECDHE-%s",
+            polarssl_snprintf( title, sizeof( title ), "ECDHE-%s",
                                               curve_info->name );
             TIME_PUBLIC( title, "handshake",
                     ret |= ecdh_make_public( &ecdh, &olen, buf, sizeof( buf),
@@ -634,7 +635,7 @@ int main( int argc, char *argv[] )
                     ret |= ecdh_calc_secret( &ecdh, &olen, buf, sizeof( buf ),
                                              myrand, NULL ) );
 
-            snprintf( title, sizeof( title ), "ECDH-%s",
+            polarssl_snprintf( title, sizeof( title ), "ECDH-%s",
                                               curve_info->name );
             TIME_PUBLIC( title, "handshake",
                     ret |= ecdh_calc_secret( &ecdh, &olen, buf, sizeof( buf ),

--- a/programs/test/benchmark.c
+++ b/programs/test/benchmark.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -71,7 +80,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_TIMING_C not defined.\n");
+    polarssl_printf("POLARSSL_TIMING_C not defined.\n");
     return( 0 );
 }
 #else
@@ -103,7 +112,7 @@ static int myrand( void *rng_state, unsigned char *output, size_t len )
 do {                                                                    \
     unsigned long i, j, tsc;                                            \
                                                                         \
-    printf( HEADER_FORMAT, TITLE );                                     \
+    polarssl_printf( HEADER_FORMAT, TITLE );                                     \
     fflush( stdout );                                                   \
                                                                         \
     set_alarm( 1 );                                                     \
@@ -118,17 +127,17 @@ do {                                                                    \
         CODE;                                                           \
     }                                                                   \
                                                                         \
-    printf( "%9lu Kb/s,  %9lu cycles/byte\n", i * BUFSIZE / 1024,       \
+    polarssl_printf( "%9lu Kb/s,  %9lu cycles/byte\n", i * BUFSIZE / 1024,       \
                     ( hardclock() - tsc ) / ( j * BUFSIZE ) );          \
 } while( 0 )
 
 #if defined(POLARSSL_ERROR_C)
 #define PRINT_ERROR                                                     \
         polarssl_strerror( ret, ( char * )tmp, sizeof( tmp ) );         \
-        printf( "FAILED: %s\n", tmp );
+        polarssl_printf( "FAILED: %s\n", tmp );
 #else
 #define PRINT_ERROR                                                     \
-        printf( "FAILED: -0x%04x\n", -ret );
+        polarssl_printf( "FAILED: -0x%04x\n", -ret );
 #endif
 
 #define TIME_PUBLIC( TITLE, TYPE, CODE )                                \
@@ -136,7 +145,7 @@ do {                                                                    \
     unsigned long i;                                                    \
     int ret;                                                            \
                                                                         \
-    printf( HEADER_FORMAT, TITLE );                                     \
+    polarssl_printf( HEADER_FORMAT, TITLE );                                     \
     fflush( stdout );                                                   \
     set_alarm( 3 );                                                     \
                                                                         \
@@ -151,7 +160,7 @@ do {                                                                    \
 PRINT_ERROR;                                                            \
     }                                                                   \
     else                                                                \
-        printf( "%9lu " TYPE "/s\n", i / 3 );                           \
+        polarssl_printf( "%9lu " TYPE "/s\n", i / 3 );                           \
 } while( 0 )
 
 unsigned char buf[BUFSIZE];
@@ -228,13 +237,13 @@ int main( int argc, char *argv[] )
                 todo.ecdh = 1;
             else
             {
-                printf( "Unrecognized option: %s\n", argv[i] );
-                printf( "Available options: " OPTIONS );
+                polarssl_printf( "Unrecognized option: %s\n", argv[i] );
+                polarssl_printf( "Available options: " OPTIONS );
             }
         }
     }
 
-    printf( "\n" );
+    polarssl_printf( "\n" );
 
     memset( buf, 0xAA, sizeof( buf ) );
     memset( tmp, 0xBB, sizeof( tmp ) );
@@ -634,10 +643,10 @@ int main( int argc, char *argv[] )
         }
     }
 #endif
-    printf( "\n" );
+    polarssl_printf( "\n" );
 
 #if defined(_WIN32)
-    printf( "  Press Enter to exit this program.\n" );
+    polarssl_printf( "  Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/test/o_p_test.c
+++ b/programs/test/o_p_test.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -54,7 +63,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_RSA_C and/or "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_RSA_C and/or "
            "POLARSSL_PK_PARSE_C and/or POLARSSL_FS_IO not defined.\n");
     return( 0 );
 }
@@ -85,7 +94,7 @@ int main( int argc, char *argv[] )
                     (const unsigned char *) pers,
                     strlen( pers ) ) ) != 0 )
     {
-        printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
+        polarssl_printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
         goto exit;
     }
     ERR_load_crypto_strings();
@@ -94,38 +103,38 @@ int main( int argc, char *argv[] )
 
     if( argc != 3 )
     {
-        printf( "usage: o_p_test <keyfile with private_key> <string of max 100 characters>\n" );
+        polarssl_printf( "usage: o_p_test <keyfile with private_key> <string of max 100 characters>\n" );
 
 #ifdef WIN32
-        printf( "\n" );
+        polarssl_printf( "\n" );
 #endif
 
         goto exit;
     }
 
-    printf( "  . Reading private key from %s into PolarSSL ...", argv[1] );
+    polarssl_printf( "  . Reading private key from %s into PolarSSL ...", argv[1] );
     fflush( stdout );
 
     pk_init( &p_pk );
     if( pk_parse_keyfile( &p_pk, argv[1], NULL ) != 0 )
     {
         ret = 1;
-        printf( " failed\n  ! Could not load key.\n\n" );
+        polarssl_printf( " failed\n  ! Could not load key.\n\n" );
         goto exit;
     }
 
     if( !pk_can_do( &p_pk, POLARSSL_PK_RSA ) )
     {
         ret = 1;
-        printf( " failed\n  ! Key is not an RSA key\n" );
+        polarssl_printf( " failed\n  ! Key is not an RSA key\n" );
         goto exit;
     }
 
     p_rsa = pk_rsa( p_pk );
 
-    printf( " passed\n");
+    polarssl_printf( " passed\n");
 
-    printf( "  . Reading private key from %s into OpenSSL  ...", argv[1] );
+    polarssl_printf( "  . Reading private key from %s into OpenSSL  ...", argv[1] );
     fflush( stdout );
 
     key_file = fopen( argv[1], "r" );
@@ -134,16 +143,16 @@ int main( int argc, char *argv[] )
     if( o_rsa == NULL )
     {
         ret = 1;
-        printf( " failed\n  ! Could not load key.\n\n" );
+        polarssl_printf( " failed\n  ! Could not load key.\n\n" );
         goto exit;
     }
 
-    printf( " passed\n");
-    printf( "\n" );
+    polarssl_printf( " passed\n");
+    polarssl_printf( "\n" );
 
     if( strlen( argv[1] ) > 100 )
     {
-        printf( " Input data larger than 100 characters.\n\n" );
+        polarssl_printf( " Input data larger than 100 characters.\n\n" );
         goto exit;
     }
 
@@ -152,117 +161,117 @@ int main( int argc, char *argv[] )
     /*
      * Calculate the RSA encryption with public key.
      */
-    printf( "  . Generating the RSA encrypted value with PolarSSL (RSA_PUBLIC)  ..." );
+    polarssl_printf( "  . Generating the RSA encrypted value with PolarSSL (RSA_PUBLIC)  ..." );
     fflush( stdout );
 
     if( ( ret = rsa_pkcs1_encrypt( p_rsa, ctr_drbg_random, &ctr_drbg, RSA_PUBLIC, strlen( argv[2] ), input, p_pub_encrypted ) ) != 0 )
     {
-        printf( " failed\n  ! rsa_pkcs1_encrypt returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! rsa_pkcs1_encrypt returned %d\n\n", ret );
         goto exit;
     }
     else
-        printf( " passed\n");
+        polarssl_printf( " passed\n");
 
-    printf( "  . Generating the RSA encrypted value with OpenSSL (PUBLIC)       ..." );
+    polarssl_printf( "  . Generating the RSA encrypted value with OpenSSL (PUBLIC)       ..." );
     fflush( stdout );
 
     if( ( ret = RSA_public_encrypt( strlen( argv[2] ), input, o_pub_encrypted, o_rsa, RSA_PKCS1_PADDING ) ) == -1 )
     {
         unsigned long code = ERR_get_error();
-        printf( " failed\n  ! RSA_public_encrypt returned %d %s\n\n", ret, ERR_error_string( code, NULL ) );
+        polarssl_printf( " failed\n  ! RSA_public_encrypt returned %d %s\n\n", ret, ERR_error_string( code, NULL ) );
         goto exit;
     }
     else
-        printf( " passed\n");
+        polarssl_printf( " passed\n");
 
     /*
      * Calculate the RSA encryption with private key.
      */
-    printf( "  . Generating the RSA encrypted value with PolarSSL (RSA_PRIVATE) ..." );
+    polarssl_printf( "  . Generating the RSA encrypted value with PolarSSL (RSA_PRIVATE) ..." );
     fflush( stdout );
 
     if( ( ret = rsa_pkcs1_encrypt( p_rsa, ctr_drbg_random, &ctr_drbg, RSA_PRIVATE, strlen( argv[2] ), input, p_priv_encrypted ) ) != 0 )
     {
-        printf( " failed\n  ! rsa_pkcs1_encrypt returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! rsa_pkcs1_encrypt returned %d\n\n", ret );
         goto exit;
     }
     else
-        printf( " passed\n");
+        polarssl_printf( " passed\n");
 
-    printf( "  . Generating the RSA encrypted value with OpenSSL (PRIVATE)      ..." );
+    polarssl_printf( "  . Generating the RSA encrypted value with OpenSSL (PRIVATE)      ..." );
     fflush( stdout );
 
     if( ( ret = RSA_private_encrypt( strlen( argv[2] ), input, o_priv_encrypted, o_rsa, RSA_PKCS1_PADDING ) ) == -1 )
     {
         unsigned long code = ERR_get_error();
-        printf( " failed\n  ! RSA_private_encrypt returned %d %s\n\n", ret, ERR_error_string( code, NULL ) );
+        polarssl_printf( " failed\n  ! RSA_private_encrypt returned %d %s\n\n", ret, ERR_error_string( code, NULL ) );
         goto exit;
     }
     else
-        printf( " passed\n");
+        polarssl_printf( " passed\n");
 
-    printf( "\n" );
+    polarssl_printf( "\n" );
 
     /*
      * Calculate the RSA decryption with private key.
      */
-    printf( "  . Generating the RSA decrypted value for OpenSSL (PUBLIC) with PolarSSL (PRIVATE) ..." );
+    polarssl_printf( "  . Generating the RSA decrypted value for OpenSSL (PUBLIC) with PolarSSL (PRIVATE) ..." );
     fflush( stdout );
 
     if( ( ret = rsa_pkcs1_decrypt( p_rsa, ctr_drbg_random, &ctr_drbg, RSA_PRIVATE, &olen, o_pub_encrypted, p_pub_decrypted, 1024 ) ) != 0 )
     {
-        printf( " failed\n  ! rsa_pkcs1_decrypt returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! rsa_pkcs1_decrypt returned %d\n\n", ret );
     }
     else
-        printf( " passed\n");
+        polarssl_printf( " passed\n");
 
-    printf( "  . Generating the RSA decrypted value for PolarSSL (PUBLIC) with OpenSSL (PRIVATE) ..." );
+    polarssl_printf( "  . Generating the RSA decrypted value for PolarSSL (PUBLIC) with OpenSSL (PRIVATE) ..." );
     fflush( stdout );
 
     if( ( ret = RSA_private_decrypt( p_rsa->len, p_pub_encrypted, o_pub_decrypted, o_rsa, RSA_PKCS1_PADDING ) ) == -1 )
     {
         unsigned long code = ERR_get_error();
-        printf( " failed\n  ! RSA_private_decrypt returned %d %s\n\n", ret, ERR_error_string( code, NULL ) );
+        polarssl_printf( " failed\n  ! RSA_private_decrypt returned %d %s\n\n", ret, ERR_error_string( code, NULL ) );
     }
     else
-        printf( " passed\n");
+        polarssl_printf( " passed\n");
 
     /*
      * Calculate the RSA decryption with public key.
      */
-    printf( "  . Generating the RSA decrypted value for OpenSSL (PRIVATE) with PolarSSL (PUBLIC) ..." );
+    polarssl_printf( "  . Generating the RSA decrypted value for OpenSSL (PRIVATE) with PolarSSL (PUBLIC) ..." );
     fflush( stdout );
 
     if( ( ret = rsa_pkcs1_decrypt( p_rsa, NULL, NULL, RSA_PUBLIC, &olen, o_priv_encrypted, p_priv_decrypted, 1024 ) ) != 0 )
     {
-        printf( " failed\n  ! rsa_pkcs1_decrypt returned %d\n\n", ret );
+        polarssl_printf( " failed\n  ! rsa_pkcs1_decrypt returned %d\n\n", ret );
     }
     else
-        printf( " passed\n");
+        polarssl_printf( " passed\n");
 
-    printf( "  . Generating the RSA decrypted value for PolarSSL (PRIVATE) with OpenSSL (PUBLIC) ..." );
+    polarssl_printf( "  . Generating the RSA decrypted value for PolarSSL (PRIVATE) with OpenSSL (PUBLIC) ..." );
     fflush( stdout );
 
     if( ( ret = RSA_public_decrypt( p_rsa->len, p_priv_encrypted, o_priv_decrypted, o_rsa, RSA_PKCS1_PADDING ) ) == -1 )
     {
         unsigned long code = ERR_get_error();
-        printf( " failed\n  ! RSA_public_decrypt returned %d %s\n\n", ret, ERR_error_string( code, NULL ) );
+        polarssl_printf( " failed\n  ! RSA_public_decrypt returned %d %s\n\n", ret, ERR_error_string( code, NULL ) );
     }
     else
-        printf( " passed\n");
+        polarssl_printf( " passed\n");
 
-    printf( "\n" );
-    printf( "String value (OpenSSL Public Encrypt, PolarSSL Private Decrypt): '%s'\n", p_pub_decrypted );
-    printf( "String value (PolarSSL Public Encrypt, OpenSSL Private Decrypt): '%s'\n", o_pub_decrypted );
-    printf( "String value (OpenSSL Private Encrypt, PolarSSL Public Decrypt): '%s'\n", p_priv_decrypted );
-    printf( "String value (PolarSSL Private Encrypt, OpenSSL Public Decrypt): '%s'\n", o_priv_decrypted );
+    polarssl_printf( "\n" );
+    polarssl_printf( "String value (OpenSSL Public Encrypt, PolarSSL Private Decrypt): '%s'\n", p_pub_decrypted );
+    polarssl_printf( "String value (PolarSSL Public Encrypt, OpenSSL Private Decrypt): '%s'\n", o_pub_decrypted );
+    polarssl_printf( "String value (OpenSSL Private Encrypt, PolarSSL Public Decrypt): '%s'\n", p_priv_decrypted );
+    polarssl_printf( "String value (PolarSSL Private Encrypt, OpenSSL Public Decrypt): '%s'\n", o_priv_decrypted );
 
 exit:
     ctr_drbg_free( &ctr_drbg );
     entropy_free( &entropy );
 
 #ifdef WIN32
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/test/selftest.c
+++ b/programs/test/selftest.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdio.h>
 
@@ -75,7 +84,7 @@ int main( int argc, char *argv[] )
     else
     {
         v = 1;
-        printf( "\n" );
+        polarssl_printf( "\n" );
     }
 
 #if defined(POLARSSL_SELF_TEST)
@@ -218,7 +227,7 @@ int main( int argc, char *argv[] )
 #endif
 
 #else
-    printf( " POLARSSL_SELF_TEST not defined.\n" );
+    polarssl_printf( " POLARSSL_SELF_TEST not defined.\n" );
 #endif
 
     if( v != 0 )
@@ -227,9 +236,9 @@ int main( int argc, char *argv[] )
         memory_buffer_alloc_status();
 #endif
 
-        printf( "  [ All tests passed ]\n\n" );
+        polarssl_printf( "  [ All tests passed ]\n\n" );
 #if defined(_WIN32)
-        printf( "  Press Enter to exit this program.\n" );
+        polarssl_printf( "  Press Enter to exit this program.\n" );
         fflush( stdout ); getchar();
 #endif
     }

--- a/programs/test/ssl_cert_test.c
+++ b/programs/test/ssl_cert_test.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdio.h>
 
@@ -39,7 +48,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_RSA_C and/or POLARSSL_X509_CRT_PARSE_C "
+    polarssl_printf("POLARSSL_RSA_C and/or POLARSSL_X509_CRT_PARSE_C "
            "POLARSSL_FS_IO and/or POLARSSL_X509_CRL_PARSE_C "
            "not defined.\n");
     return( 0 );
@@ -96,7 +105,7 @@ int main( int argc, char *argv[] )
     /*
      * 1.1. Load the trusted CA
      */
-    printf( "\n  . Loading the CA root certificate ..." );
+    polarssl_printf( "\n  . Loading the CA root certificate ..." );
     fflush( stdout );
 
     /*
@@ -106,32 +115,32 @@ int main( int argc, char *argv[] )
     ret = x509_crt_parse_file( &cacert, "ssl/test-ca/test-ca.crt" );
     if( ret != 0 )
     {
-        printf( " failed\n  !  x509_crt_parse_file returned %d\n\n", ret );
+        polarssl_printf( " failed\n  !  x509_crt_parse_file returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     x509_crt_info( buf, 1024, "CRT: ", &cacert );
-    printf("%s\n", buf );
+    polarssl_printf("%s\n", buf );
 
     /*
      * 1.2. Load the CRL
      */
-    printf( "  . Loading the CRL ..." );
+    polarssl_printf( "  . Loading the CRL ..." );
     fflush( stdout );
 
     ret = x509_crl_parse_file( &crl, "ssl/test-ca/crl.pem" );
     if( ret != 0 )
     {
-        printf( " failed\n  !  x509_crl_parse_file returned %d\n\n", ret );
+        polarssl_printf( " failed\n  !  x509_crl_parse_file returned %d\n\n", ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     x509_crl_info( buf, 1024, "CRL: ", &crl );
-    printf("%s\n", buf );
+    polarssl_printf("%s\n", buf );
 
     for( i = 0; i < MAX_CLIENT_CERTS; i++ )
     {
@@ -148,22 +157,22 @@ int main( int argc, char *argv[] )
 
         snprintf(name, 512, "ssl/test-ca/%s", client_certificates[i]);
 
-        printf( "  . Loading the client certificate %s...", name );
+        polarssl_printf( "  . Loading the client certificate %s...", name );
         fflush( stdout );
 
         ret = x509_crt_parse_file( &clicert, name );
         if( ret != 0 )
         {
-            printf( " failed\n  !  x509_crt_parse_file returned %d\n\n", ret );
+            polarssl_printf( " failed\n  !  x509_crt_parse_file returned %d\n\n", ret );
             goto exit;
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
 
         /*
          * 1.4. Verify certificate validity with CA certificate
          */
-        printf( "  . Verify the client certificate with CA certificate..." );
+        polarssl_printf( "  . Verify the client certificate with CA certificate..." );
         fflush( stdout );
 
         ret = x509_crt_verify( &clicert, &cacert, &crl, NULL, &flags, NULL,
@@ -173,53 +182,53 @@ int main( int argc, char *argv[] )
             if( ret == POLARSSL_ERR_X509_CERT_VERIFY_FAILED )
             {
                 if( flags & BADCERT_CN_MISMATCH )
-                    printf( " CN_MISMATCH " );
+                    polarssl_printf( " CN_MISMATCH " );
                 if( flags & BADCERT_EXPIRED )
-                    printf( " EXPIRED " );
+                    polarssl_printf( " EXPIRED " );
                 if( flags & BADCERT_REVOKED )
-                    printf( " REVOKED " );
+                    polarssl_printf( " REVOKED " );
                 if( flags & BADCERT_NOT_TRUSTED )
-                    printf( " NOT_TRUSTED " );
+                    polarssl_printf( " NOT_TRUSTED " );
                 if( flags & BADCRL_NOT_TRUSTED )
-                    printf( " CRL_NOT_TRUSTED " );
+                    polarssl_printf( " CRL_NOT_TRUSTED " );
                 if( flags & BADCRL_EXPIRED )
-                    printf( " CRL_EXPIRED " );
+                    polarssl_printf( " CRL_EXPIRED " );
             } else {
-                printf( " failed\n  !  x509_crt_verify returned %d\n\n", ret );
+                polarssl_printf( " failed\n  !  x509_crt_verify returned %d\n\n", ret );
                 goto exit;
             }
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
 
         /*
          * 1.5. Load own private key
          */
         snprintf(name, 512, "ssl/test-ca/%s", client_private_keys[i]);
 
-        printf( "  . Loading the client private key %s...", name );
+        polarssl_printf( "  . Loading the client private key %s...", name );
         fflush( stdout );
 
         ret = pk_parse_keyfile( &pk, name, NULL );
         if( ret != 0 )
         {
-            printf( " failed\n  !  pk_parse_keyfile returned %d\n\n", ret );
+            polarssl_printf( " failed\n  !  pk_parse_keyfile returned %d\n\n", ret );
             goto exit;
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
 
         /*
          * 1.6. Verify certificate validity with private key
          */
-        printf( "  . Verify the client certificate with private key..." );
+        polarssl_printf( "  . Verify the client certificate with private key..." );
         fflush( stdout );
 
 
         /* EC NOT IMPLEMENTED YET */
         if( ! pk_can_do( &clicert.pk, POLARSSL_PK_RSA ) )
         {
-            printf( " failed\n  !  certificate's key is not RSA\n\n" );
+            polarssl_printf( " failed\n  !  certificate's key is not RSA\n\n" );
             ret = POLARSSL_ERR_X509_FEATURE_UNAVAILABLE;
             goto exit;
         }
@@ -227,25 +236,25 @@ int main( int argc, char *argv[] )
         ret = mpi_cmp_mpi(&pk_rsa( pk )->N, &pk_rsa( clicert.pk )->N);
         if( ret != 0 )
         {
-            printf( " failed\n  !  mpi_cmp_mpi for N returned %d\n\n", ret );
+            polarssl_printf( " failed\n  !  mpi_cmp_mpi for N returned %d\n\n", ret );
             goto exit;
         }
 
         ret = mpi_cmp_mpi(&pk_rsa( pk )->E, &pk_rsa( clicert.pk )->E);
         if( ret != 0 )
         {
-            printf( " failed\n  !  mpi_cmp_mpi for E returned %d\n\n", ret );
+            polarssl_printf( " failed\n  !  mpi_cmp_mpi for E returned %d\n\n", ret );
             goto exit;
         }
 
         ret = rsa_check_privkey( pk_rsa( pk ) );
         if( ret != 0 )
         {
-            printf( " failed\n  !  rsa_check_privkey returned %d\n\n", ret );
+            polarssl_printf( " failed\n  !  rsa_check_privkey returned %d\n\n", ret );
             goto exit;
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
 
         x509_crt_free( &clicert );
         pk_free( &pk );
@@ -256,7 +265,7 @@ exit:
     x509_crl_free( &crl );
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/test/ssl_cert_test.c
+++ b/programs/test/ssl_cert_test.c
@@ -32,6 +32,7 @@
 #if defined(POLARSSL_PLATFORM_C)
 #include "polarssl/platform.h"
 #else
+#define polarssl_snprintf   snprintf
 #define polarssl_printf     printf
 #define polarssl_fprintf    fprintf
 #define polarssl_malloc     malloc
@@ -155,7 +156,7 @@ int main( int argc, char *argv[] )
         x509_crt_init( &clicert );
         pk_init( &pk );
 
-        snprintf(name, 512, "ssl/test-ca/%s", client_certificates[i]);
+        polarssl_snprintf(name, 512, "ssl/test-ca/%s", client_certificates[i]);
 
         polarssl_printf( "  . Loading the client certificate %s...", name );
         fflush( stdout );
@@ -204,7 +205,7 @@ int main( int argc, char *argv[] )
         /*
          * 1.5. Load own private key
          */
-        snprintf(name, 512, "ssl/test-ca/%s", client_private_keys[i]);
+        polarssl_snprintf(name, 512, "ssl/test-ca/%s", client_private_keys[i]);
 
         polarssl_printf( "  . Loading the client private key %s...", name );
         fflush( stdout );

--- a/programs/test/ssl_test.c
+++ b/programs/test/ssl_test.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -52,7 +61,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_ENTROPY_C and/or "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_ENTROPY_C and/or "
            "POLARSSL_SSL_TLS_C and/or POLARSSL_SSL_SRV_C and/or "
            "POLARSSL_SSL_CLI_C and/or POLARSSL_NET_C and/or "
            "POLARSSL_RSA_C and/or POLARSSL_CTR_DRBG_C and/or "
@@ -134,7 +143,7 @@ static unsigned long int lcppm5( unsigned long int *state )
 static void my_debug( void *ctx, int level, const char *str )
 {
     if( level < ((struct options *) ctx)->debug_level )
-        fprintf( stderr, "%s", str );
+        polarssl_fprintf( stderr, "%s", str );
 }
 
 /*
@@ -178,7 +187,7 @@ static int ssl_test( struct options *opt )
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        printf( "  ! ctr_drbg_init returned %d\n", ret );
+        polarssl_printf( "  ! ctr_drbg_init returned %d\n", ret );
         goto exit;
     }
 
@@ -195,13 +204,13 @@ static int ssl_test( struct options *opt )
         if( ( ret = net_connect( &client_fd, opt->server_name,
                                              opt->server_port ) ) != 0 )
         {
-            printf( "  ! net_connect returned %d\n\n", ret );
+            polarssl_printf( "  ! net_connect returned %d\n\n", ret );
             return( ret );
         }
 
         if( ( ret = ssl_init( &ssl ) ) != 0 )
         {
-            printf( "  ! ssl_init returned %d\n\n", ret );
+            polarssl_printf( "  ! ssl_init returned %d\n\n", ret );
             goto exit;
         }
 
@@ -211,14 +220,14 @@ static int ssl_test( struct options *opt )
     if( opt->opmode == OPMODE_SERVER )
     {
 #if !defined(POLARSSL_CERTS_C)
-        printf("POLARSSL_CERTS_C not defined.\n");
+        polarssl_printf("POLARSSL_CERTS_C not defined.\n");
         goto exit;
 #else
         ret =  x509_crt_parse( &srvcert, (const unsigned char *) test_srv_crt,
                                strlen( test_srv_crt ) );
         if( ret != 0 )
         {
-            printf( "  !  x509_crt_parse returned %d\n\n", ret );
+            polarssl_printf( "  !  x509_crt_parse returned %d\n\n", ret );
             goto exit;
         }
 
@@ -226,7 +235,7 @@ static int ssl_test( struct options *opt )
                                strlen( test_ca_list ) );
         if( ret != 0 )
         {
-            printf( "  !  x509_crt_parse returned %d\n\n", ret );
+            polarssl_printf( "  !  x509_crt_parse returned %d\n\n", ret );
             goto exit;
         }
 
@@ -234,7 +243,7 @@ static int ssl_test( struct options *opt )
                              strlen( test_srv_key ), NULL, 0 );
         if( ret != 0 )
         {
-            printf( "  !  pk_parse_key returned %d\n\n", ret );
+            polarssl_printf( "  !  pk_parse_key returned %d\n\n", ret );
             goto exit;
         }
 #endif
@@ -244,20 +253,20 @@ static int ssl_test( struct options *opt )
             if( ( ret = net_bind( &server_fd, NULL,
                                    opt->server_port ) ) != 0 )
             {
-                printf( "  ! net_bind returned %d\n\n", ret );
+                polarssl_printf( "  ! net_bind returned %d\n\n", ret );
                 return( ret );
             }
         }
 
         if( ( ret = net_accept( server_fd, &client_fd, NULL ) ) != 0 )
         {
-            printf( "  ! net_accept returned %d\n\n", ret );
+            polarssl_printf( "  ! net_accept returned %d\n\n", ret );
             return( ret );
         }
 
         if( ( ret = ssl_init( &ssl ) ) != 0 )
         {
-            printf( "  ! ssl_init returned %d\n\n", ret );
+            polarssl_printf( "  ! ssl_init returned %d\n\n", ret );
             return( ret );
         }
 
@@ -265,7 +274,7 @@ static int ssl_test( struct options *opt )
         ssl_set_ca_chain( &ssl, srvcert.next, NULL, NULL );
         if( ( ret = ssl_set_own_cert( &ssl, &srvcert, &pkey ) ) != 0 )
         {
-            printf( " failed\n  ! ssl_set_own_cert returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_set_own_cert returned %d\n\n", ret );
             goto exit;
         }
     }
@@ -284,17 +293,17 @@ static int ssl_test( struct options *opt )
     {
         if( ( ret = net_set_nonblock( client_fd ) ) != 0 )
         {
-            printf( "  ! net_set_nonblock returned %d\n\n", ret );
+            polarssl_printf( "  ! net_set_nonblock returned %d\n\n", ret );
             return( ret );
         }
     }
 
-     read_buf = (unsigned char *) malloc( opt->buffer_size );
-    write_buf = (unsigned char *) malloc( opt->buffer_size );
+     read_buf = (unsigned char *) polarssl_malloc( opt->buffer_size );
+    write_buf = (unsigned char *) polarssl_malloc( opt->buffer_size );
 
     if( read_buf == NULL || write_buf == NULL )
     {
-        printf( "  ! malloc(%d bytes) failed\n\n", opt->buffer_size );
+        polarssl_printf( "  ! polarssl_malloc(%d bytes) failed\n\n", opt->buffer_size );
         goto exit;
     }
 
@@ -336,7 +345,7 @@ static int ssl_test( struct options *opt )
             if( ret < 0 && ret != POLARSSL_ERR_NET_WANT_READ &&
                 ret != POLARSSL_ERR_NET_WANT_WRITE )
             {
-                printf( "  ! ssl_write returned %d\n\n", ret );
+                polarssl_printf( "  ! ssl_write returned %d\n\n", ret );
                 break;
             }
         }
@@ -360,7 +369,7 @@ static int ssl_test( struct options *opt )
                         (unsigned char) lcppm5( read_state ) )
                     {
                         ret = 1;
-                        printf( "  ! plaintext mismatch\n\n" );
+                        polarssl_printf( "  ! plaintext mismatch\n\n" );
                         goto exit;
                     }
                 }
@@ -382,7 +391,7 @@ static int ssl_test( struct options *opt )
             if( ret < 0 && ret != POLARSSL_ERR_NET_WANT_READ &&
                 ret != POLARSSL_ERR_NET_WANT_WRITE )
             {
-                printf( "  ! ssl_read returned %d\n\n", ret );
+                polarssl_printf( "  ! ssl_read returned %d\n\n", ret );
                 break;
             }
         }
@@ -461,15 +470,15 @@ int main( int argc, char *argv[] )
     if( argc == 1 )
     {
     usage:
-        printf( USAGE );
+        polarssl_printf( USAGE );
 
         list = ssl_list_ciphersuites();
         while( *list )
         {
-            printf("    %s\n", ssl_get_ciphersuite_name( *list ) );
+            polarssl_printf("    %s\n", ssl_get_ciphersuite_name( *list ) );
             list++;
         }
-        printf("\n");
+        polarssl_printf("\n");
         goto exit;
     }
 
@@ -614,7 +623,7 @@ int main( int argc, char *argv[] )
 exit:
 
 #if defined(_WIN32)
-    printf( "  Press Enter to exit this program.\n" );
+    polarssl_printf( "  Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/util/pem2der.c
+++ b/programs/util/pem2der.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -45,7 +54,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BASE64_C and/or POLARSSL_FS_IO not defined.\n");
+    polarssl_printf("POLARSSL_BASE64_C and/or POLARSSL_FS_IO not defined.\n");
     return( 0 );
 }
 #else
@@ -124,7 +133,7 @@ static int load_file( const char *path, unsigned char **buf, size_t *n )
     *n = (size_t) size;
 
     if( *n + 1 == 0 ||
-        ( *buf = (unsigned char *) malloc( *n + 1 ) ) == NULL )
+        ( *buf = (unsigned char *) polarssl_malloc( *n + 1 ) ) == NULL )
     {
         fclose( f );
         return( -1 );
@@ -191,7 +200,7 @@ int main( int argc, char *argv[] )
     if( argc == 0 )
     {
     usage:
-        printf( USAGE );
+        polarssl_printf( USAGE );
         goto exit;
     }
 
@@ -217,7 +226,7 @@ int main( int argc, char *argv[] )
     /*
      * 1.1. Load the PEM file
      */
-    printf( "\n  . Loading the PEM file ..." );
+    polarssl_printf( "\n  . Loading the PEM file ..." );
     fflush( stdout );
 
     ret = load_file( opt.filename, &pem_buffer, &pem_size );
@@ -227,16 +236,16 @@ int main( int argc, char *argv[] )
 #ifdef POLARSSL_ERROR_C
         polarssl_strerror( ret, buf, 1024 );
 #endif
-        printf( " failed\n  !  load_file returned %d - %s\n\n", ret, buf );
+        polarssl_printf( " failed\n  !  load_file returned %d - %s\n\n", ret, buf );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 1.2. Convert from PEM to DER
      */
-    printf( "  . Converting from PEM to DER ..." );
+    polarssl_printf( "  . Converting from PEM to DER ..." );
     fflush( stdout );
 
     if( ( ret = convert_pem_to_der( pem_buffer, pem_size, der_buffer, &der_size ) ) != 0 )
@@ -244,16 +253,16 @@ int main( int argc, char *argv[] )
 #ifdef POLARSSL_ERROR_C
         polarssl_strerror( ret, buf, 1024 );
 #endif
-        printf( " failed\n  !  convert_pem_to_der %d - %s\n\n", ret, buf );
+        polarssl_printf( " failed\n  !  convert_pem_to_der %d - %s\n\n", ret, buf );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 1.3. Write the DER file
      */
-    printf( "  . Writing the DER file ..." );
+    polarssl_printf( "  . Writing the DER file ..." );
     fflush( stdout );
 
     ret = write_file( opt.output_file, der_buffer, der_size );
@@ -263,17 +272,17 @@ int main( int argc, char *argv[] )
 #ifdef POLARSSL_ERROR_C
         polarssl_strerror( ret, buf, 1024 );
 #endif
-        printf( " failed\n  !  write_file returned %d - %s\n\n", ret, buf );
+        polarssl_printf( " failed\n  !  write_file returned %d - %s\n\n", ret, buf );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
 exit:
     free( pem_buffer );
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/util/strerror.c
+++ b/programs/util/strerror.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -45,7 +54,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_ERROR_C and/or POLARSSL_ERROR_STRERROR_DUMMY not defined.\n");
+    polarssl_printf("POLARSSL_ERROR_C and/or POLARSSL_ERROR_STRERROR_DUMMY not defined.\n");
     return( 0 );
 }
 #else
@@ -56,7 +65,7 @@ int main( int argc, char *argv[] )
 
     if( argc != 2 )
     {
-        printf( USAGE );
+        polarssl_printf( USAGE );
         return( 0 );
     }
 
@@ -66,7 +75,7 @@ int main( int argc, char *argv[] )
         val = strtol( argv[1], &end, 16 );
         if( *end != '\0' )
         {
-            printf( USAGE );
+            polarssl_printf( USAGE );
             return( 0 );
         }
     }
@@ -77,11 +86,11 @@ int main( int argc, char *argv[] )
     {
         char error_buf[200];
         polarssl_strerror( val, error_buf, 200 );
-        printf("Last error was: -0x%04x - %s\n\n", (int) -val, error_buf );
+        polarssl_printf("Last error was: -0x%04x - %s\n\n", (int) -val, error_buf );
     }
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/x509/cert_app.c
+++ b/programs/x509/cert_app.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -49,7 +58,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_ENTROPY_C and/or "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_ENTROPY_C and/or "
            "POLARSSL_SSL_TLS_C and/or POLARSSL_SSL_CLI_C and/or "
            "POLARSSL_NET_C and/or POLARSSL_RSA_C and/or "
            "POLARSSL_X509_CRT_PARSE_C and/or POLARSSL_FS_IO and/or "
@@ -92,7 +101,7 @@ static void my_debug( void *ctx, int level, const char *str )
 {
     if( level < opt.debug_level )
     {
-        fprintf( (FILE *) ctx, "%s", str );
+        polarssl_fprintf( (FILE *) ctx, "%s", str );
         fflush(  (FILE *) ctx  );
     }
 }
@@ -102,33 +111,33 @@ static int my_verify( void *data, x509_crt *crt, int depth, int *flags )
     char buf[1024];
     ((void) data);
 
-    printf( "\nVerify requested for (Depth %d):\n", depth );
+    polarssl_printf( "\nVerify requested for (Depth %d):\n", depth );
     x509_crt_info( buf, sizeof( buf ) - 1, "", crt );
-    printf( "%s", buf );
+    polarssl_printf( "%s", buf );
 
     if( ( (*flags) & BADCERT_EXPIRED ) != 0 )
-        printf( "  ! server certificate has expired\n" );
+        polarssl_printf( "  ! server certificate has expired\n" );
 
     if( ( (*flags) & BADCERT_REVOKED ) != 0 )
-        printf( "  ! server certificate has been revoked\n" );
+        polarssl_printf( "  ! server certificate has been revoked\n" );
 
     if( ( (*flags) & BADCERT_CN_MISMATCH ) != 0 )
-        printf( "  ! CN mismatch\n" );
+        polarssl_printf( "  ! CN mismatch\n" );
 
     if( ( (*flags) & BADCERT_NOT_TRUSTED ) != 0 )
-        printf( "  ! self-signed or not signed by a trusted CA\n" );
+        polarssl_printf( "  ! self-signed or not signed by a trusted CA\n" );
 
     if( ( (*flags) & BADCRL_NOT_TRUSTED ) != 0 )
-        printf( "  ! CRL not trusted\n" );
+        polarssl_printf( "  ! CRL not trusted\n" );
 
     if( ( (*flags) & BADCRL_EXPIRED ) != 0 )
-        printf( "  ! CRL expired\n" );
+        polarssl_printf( "  ! CRL expired\n" );
 
     if( ( (*flags) & BADCERT_OTHER ) != 0 )
-        printf( "  ! other (unknown) flag\n" );
+        polarssl_printf( "  ! other (unknown) flag\n" );
 
     if ( ( *flags ) == 0 )
-        printf( "  This certificate has no flags\n" );
+        polarssl_printf( "  This certificate has no flags\n" );
 
     return( 0 );
 }
@@ -187,7 +196,7 @@ int main( int argc, char *argv[] )
     if( argc == 0 )
     {
     usage:
-        printf( USAGE );
+        polarssl_printf( USAGE );
         goto exit;
     }
 
@@ -258,7 +267,7 @@ int main( int argc, char *argv[] )
     /*
      * 1.1. Load the trusted CA
      */
-    printf( "  . Loading the CA root certificate ..." );
+    polarssl_printf( "  . Loading the CA root certificate ..." );
     fflush( stdout );
 
     if( strlen( opt.ca_path ) )
@@ -274,18 +283,18 @@ int main( int argc, char *argv[] )
 
     if( ret < 0 )
     {
-        printf( " failed\n  !  x509_crt_parse returned -0x%x\n\n", -ret );
+        polarssl_printf( " failed\n  !  x509_crt_parse returned -0x%x\n\n", -ret );
         goto exit;
     }
 
-    printf( " ok (%d skipped)\n", ret );
+    polarssl_printf( " ok (%d skipped)\n", ret );
 
 #if defined(POLARSSL_X509_CRL_PARSE_C)
     if( strlen( opt.crl_file ) )
     {
         if( ( ret = x509_crl_parse_file( &cacrl, opt.crl_file ) ) != 0 )
         {
-            printf( " failed\n  !  x509_crl_parse returned -0x%x\n\n", -ret );
+            polarssl_printf( " failed\n  !  x509_crl_parse returned -0x%x\n\n", -ret );
             goto exit;
         }
 
@@ -302,43 +311,43 @@ int main( int argc, char *argv[] )
         /*
          * 1.1. Load the certificate(s)
          */
-        printf( "\n  . Loading the certificate(s) ..." );
+        polarssl_printf( "\n  . Loading the certificate(s) ..." );
         fflush( stdout );
 
         ret = x509_crt_parse_file( &crt, opt.filename );
 
         if( ret < 0 )
         {
-            printf( " failed\n  !  x509_crt_parse_file returned %d\n\n", ret );
+            polarssl_printf( " failed\n  !  x509_crt_parse_file returned %d\n\n", ret );
             x509_crt_free( &crt );
             goto exit;
         }
 
         if( opt.permissive == 0 && ret > 0 )
         {
-            printf( " failed\n  !  x509_crt_parse failed to parse %d certificates\n\n", ret );
+            polarssl_printf( " failed\n  !  x509_crt_parse failed to parse %d certificates\n\n", ret );
             x509_crt_free( &crt );
             goto exit;
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
 
         /*
          * 1.2 Print the certificate(s)
          */
         while( cur != NULL )
         {
-            printf( "  . Peer certificate information    ...\n" );
+            polarssl_printf( "  . Peer certificate information    ...\n" );
             ret = x509_crt_info( (char *) buf, sizeof( buf ) - 1, "      ",
                                  cur );
             if( ret == -1 )
             {
-                printf( " failed\n  !  x509_crt_info returned %d\n\n", ret );
+                polarssl_printf( " failed\n  !  x509_crt_info returned %d\n\n", ret );
                 x509_crt_free( &crt );
                 goto exit;
             }
 
-            printf( "%s\n", buf );
+            polarssl_printf( "%s\n", buf );
 
             cur = cur->next;
         }
@@ -348,29 +357,29 @@ int main( int argc, char *argv[] )
          */
         if( verify )
         {
-            printf( "  . Verifying X.509 certificate..." );
+            polarssl_printf( "  . Verifying X.509 certificate..." );
 
             if( ( ret = x509_crt_verify( &crt, &cacert, &cacrl, NULL, &flags,
                                          my_verify, NULL ) ) != 0 )
             {
-                printf( " failed\n" );
+                polarssl_printf( " failed\n" );
 
                 if( ( ret & BADCERT_EXPIRED ) != 0 )
-                    printf( "  ! server certificate has expired\n" );
+                    polarssl_printf( "  ! server certificate has expired\n" );
 
                 if( ( ret & BADCERT_REVOKED ) != 0 )
-                    printf( "  ! server certificate has been revoked\n" );
+                    polarssl_printf( "  ! server certificate has been revoked\n" );
 
                 if( ( ret & BADCERT_CN_MISMATCH ) != 0 )
-                    printf( "  ! CN mismatch (expected CN=%s)\n", opt.server_name );
+                    polarssl_printf( "  ! CN mismatch (expected CN=%s)\n", opt.server_name );
 
                 if( ( ret & BADCERT_NOT_TRUSTED ) != 0 )
-                    printf( "  ! self-signed or not signed by a trusted CA\n" );
+                    polarssl_printf( "  ! self-signed or not signed by a trusted CA\n" );
 
-                printf( "\n" );
+                polarssl_printf( "\n" );
             }
             else
-                printf( " ok\n" );
+                polarssl_printf( " ok\n" );
         }
 
         x509_crt_free( &crt );
@@ -380,7 +389,7 @@ int main( int argc, char *argv[] )
         /*
          * 1. Initialize the RNG and the session data
          */
-        printf( "\n  . Seeding the random number generator..." );
+        polarssl_printf( "\n  . Seeding the random number generator..." );
         fflush( stdout );
 
         entropy_init( &entropy );
@@ -388,23 +397,23 @@ int main( int argc, char *argv[] )
                                    (const unsigned char *) pers,
                                    strlen( pers ) ) ) != 0 )
         {
-            printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
+            polarssl_printf( " failed\n  ! ctr_drbg_init returned %d\n", ret );
             goto exit;
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
 
         /*
          * 2. Start the connection
          */
-        printf( "  . SSL connection to tcp/%s/%-4d...", opt.server_name,
+        polarssl_printf( "  . SSL connection to tcp/%s/%-4d...", opt.server_name,
                                                         opt.server_port );
         fflush( stdout );
 
         if( ( ret = net_connect( &server_fd, opt.server_name,
                                              opt.server_port ) ) != 0 )
         {
-            printf( " failed\n  ! net_connect returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! net_connect returned %d\n\n", ret );
             goto exit;
         }
 
@@ -413,7 +422,7 @@ int main( int argc, char *argv[] )
          */
         if( ( ret = ssl_init( &ssl ) ) != 0 )
         {
-            printf( " failed\n  ! ssl_init returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_init returned %d\n\n", ret );
             goto exit;
         }
 
@@ -434,14 +443,14 @@ int main( int argc, char *argv[] )
 
         if( ( ret = ssl_set_own_cert( &ssl, &clicert, &pkey ) ) != 0 )
         {
-            printf( " failed\n  ! ssl_set_own_cert returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_set_own_cert returned %d\n\n", ret );
             goto exit;
         }
 
 #if defined(POLARSSL_SSL_SERVER_NAME_INDICATION)
         if( ( ret = ssl_set_hostname( &ssl, opt.server_name ) ) != 0 )
         {
-            printf( " failed\n  ! ssl_set_hostname returned %d\n\n", ret );
+            polarssl_printf( " failed\n  ! ssl_set_hostname returned %d\n\n", ret );
             goto exit;
         }
 #endif
@@ -453,28 +462,28 @@ int main( int argc, char *argv[] )
         {
             if( ret != POLARSSL_ERR_NET_WANT_READ && ret != POLARSSL_ERR_NET_WANT_WRITE )
             {
-                printf( " failed\n  ! ssl_handshake returned %d\n\n", ret );
+                polarssl_printf( " failed\n  ! ssl_handshake returned %d\n\n", ret );
                 ssl_free( &ssl );
                 goto exit;
             }
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
 
         /*
          * 5. Print the certificate
          */
-        printf( "  . Peer certificate information    ...\n" );
+        polarssl_printf( "  . Peer certificate information    ...\n" );
         ret = x509_crt_info( (char *) buf, sizeof( buf ) - 1, "      ",
                              ssl.session->peer_cert );
         if( ret == -1 )
         {
-            printf( " failed\n  !  x509_crt_info returned %d\n\n", ret );
+            polarssl_printf( " failed\n  !  x509_crt_info returned %d\n\n", ret );
             ssl_free( &ssl );
             goto exit;
         }
 
-        printf( "%s\n", buf );
+        polarssl_printf( "%s\n", buf );
 
         ssl_close_notify( &ssl );
         ssl_free( &ssl );
@@ -496,7 +505,7 @@ exit:
     entropy_free( &entropy );
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/x509/cert_req.c
+++ b/programs/x509/cert_req.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -46,7 +55,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf( "POLARSSL_X509_CSR_WRITE_C and/or POLARSSL_FS_IO and/or "
+    polarssl_printf( "POLARSSL_X509_CSR_WRITE_C and/or POLARSSL_FS_IO and/or "
             "POLARSSL_PK_PARSE_C and/or "
             "POLARSSL_ENTROPY_C and/or POLARSSL_CTR_DRBG_C "
             "not defined.\n");
@@ -153,7 +162,7 @@ int main( int argc, char *argv[] )
     if( argc == 0 )
     {
     usage:
-        printf( USAGE );
+        polarssl_printf( USAGE );
         ret = 1;
         goto exit;
     }
@@ -254,7 +263,7 @@ int main( int argc, char *argv[] )
     /*
      * 0. Seed the PRNG
      */
-    printf( "  . Seeding the random number generator..." );
+    polarssl_printf( "  . Seeding the random number generator..." );
     fflush( stdout );
 
     entropy_init( &entropy );
@@ -262,58 +271,58 @@ int main( int argc, char *argv[] )
                                (const unsigned char *) pers,
                                strlen( pers ) ) ) != 0 )
     {
-        printf( " failed\n  !  ctr_drbg_init returned %d", ret );
+        polarssl_printf( " failed\n  !  ctr_drbg_init returned %d", ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 1.0. Check the subject name for validity
      */
-    printf( "  . Checking subjet name..." );
+    polarssl_printf( "  . Checking subjet name..." );
     fflush( stdout );
 
     if( ( ret = x509write_csr_set_subject_name( &req, opt.subject_name ) ) != 0 )
     {
-        printf( " failed\n  !  x509write_csr_set_subject_name returned %d", ret );
+        polarssl_printf( " failed\n  !  x509write_csr_set_subject_name returned %d", ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 1.1. Load the key
      */
-    printf( "  . Loading the private key ..." );
+    polarssl_printf( "  . Loading the private key ..." );
     fflush( stdout );
 
     ret = pk_parse_keyfile( &key, opt.filename, NULL );
 
     if( ret != 0 )
     {
-        printf( " failed\n  !  pk_parse_keyfile returned %d", ret );
+        polarssl_printf( " failed\n  !  pk_parse_keyfile returned %d", ret );
         goto exit;
     }
 
     x509write_csr_set_key( &req, &key );
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 1.2. Writing the request
      */
-    printf( "  . Writing the certificate request ..." );
+    polarssl_printf( "  . Writing the certificate request ..." );
     fflush( stdout );
 
     if( ( ret = write_certificate_request( &req, opt.output_file,
                                            ctr_drbg_random, &ctr_drbg ) ) != 0 )
     {
-        printf( " failed\n  !  write_certifcate_request %d", ret );
+        polarssl_printf( " failed\n  !  write_certifcate_request %d", ret );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
 exit:
 
@@ -321,9 +330,9 @@ exit:
     {
 #ifdef POLARSSL_ERROR_C
         polarssl_strerror( ret, buf, sizeof( buf ) );
-        printf( " - %s\n", buf );
+        polarssl_printf( " - %s\n", buf );
 #else
-        printf("\n");
+        polarssl_printf("\n");
 #endif
     }
 
@@ -333,7 +342,7 @@ exit:
     entropy_free( &entropy );
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/x509/cert_write.c
+++ b/programs/x509/cert_write.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -42,7 +51,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf( "POLARSSL_X509_CRT_WRITE_C and/or POLARSSL_X509_CRT_PARSE_C and/or "
+    polarssl_printf( "POLARSSL_X509_CRT_WRITE_C and/or POLARSSL_X509_CRT_PARSE_C and/or "
             "POLARSSL_FS_IO and/or "
             "POLARSSL_ENTROPY_C and/or POLARSSL_CTR_DRBG_C and/or "
             "POLARSSL_ERROR_C not defined.\n");
@@ -219,7 +228,7 @@ int main( int argc, char *argv[] )
     if( argc == 0 )
     {
     usage:
-        printf( USAGE );
+        polarssl_printf( USAGE );
         ret = 1;
         goto exit;
     }
@@ -361,12 +370,12 @@ int main( int argc, char *argv[] )
             goto usage;
     }
 
-    printf("\n");
+    polarssl_printf("\n");
 
     /*
      * 0. Seed the PRNG
      */
-    printf( "  . Seeding the random number generator..." );
+    polarssl_printf( "  . Seeding the random number generator..." );
     fflush( stdout );
 
     entropy_init( &entropy );
@@ -375,25 +384,25 @@ int main( int argc, char *argv[] )
                                strlen( pers ) ) ) != 0 )
     {
         polarssl_strerror( ret, buf, 1024 );
-        printf( " failed\n  !  ctr_drbg_init returned %d - %s\n", ret, buf );
+        polarssl_printf( " failed\n  !  ctr_drbg_init returned %d - %s\n", ret, buf );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     // Parse serial to MPI
     //
-    printf( "  . Reading serial number..." );
+    polarssl_printf( "  . Reading serial number..." );
     fflush( stdout );
 
     if( ( ret = mpi_read_string( &serial, 10, opt.serial ) ) != 0 )
     {
         polarssl_strerror( ret, buf, 1024 );
-        printf( " failed\n  !  mpi_read_string returned -0x%02x - %s\n\n", -ret, buf );
+        polarssl_printf( " failed\n  !  mpi_read_string returned -0x%02x - %s\n\n", -ret, buf );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     // Parse issuer certificate if present
     //
@@ -402,13 +411,13 @@ int main( int argc, char *argv[] )
         /*
          * 1.0.a. Load the certificates
          */
-        printf( "  . Loading the issuer certificate ..." );
+        polarssl_printf( "  . Loading the issuer certificate ..." );
         fflush( stdout );
 
         if( ( ret = x509_crt_parse_file( &issuer_crt, opt.issuer_crt ) ) != 0 )
         {
             polarssl_strerror( ret, buf, 1024 );
-            printf( " failed\n  !  x509_crt_parse_file returned -0x%02x - %s\n\n", -ret, buf );
+            polarssl_printf( " failed\n  !  x509_crt_parse_file returned -0x%02x - %s\n\n", -ret, buf );
             goto exit;
         }
 
@@ -417,13 +426,13 @@ int main( int argc, char *argv[] )
         if( ret < 0 )
         {
             polarssl_strerror( ret, buf, 1024 );
-            printf( " failed\n  !  x509_dn_gets returned -0x%02x - %s\n\n", -ret, buf );
+            polarssl_printf( " failed\n  !  x509_dn_gets returned -0x%02x - %s\n\n", -ret, buf );
             goto exit;
         }
 
         opt.issuer_name = issuer_name;
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
     }
 
 #if defined(POLARSSL_X509_CSR_PARSE_C)
@@ -434,13 +443,13 @@ int main( int argc, char *argv[] )
         /*
          * 1.0.b. Load the CSR
          */
-        printf( "  . Loading the certificate request ..." );
+        polarssl_printf( "  . Loading the certificate request ..." );
         fflush( stdout );
 
         if( ( ret = x509_csr_parse_file( &csr, opt.request_file ) ) != 0 )
         {
             polarssl_strerror( ret, buf, 1024 );
-            printf( " failed\n  !  x509_csr_parse_file returned -0x%02x - %s\n\n", -ret, buf );
+            polarssl_printf( " failed\n  !  x509_csr_parse_file returned -0x%02x - %s\n\n", -ret, buf );
             goto exit;
         }
 
@@ -449,14 +458,14 @@ int main( int argc, char *argv[] )
         if( ret < 0 )
         {
             polarssl_strerror( ret, buf, 1024 );
-            printf( " failed\n  !  x509_dn_gets returned -0x%02x - %s\n\n", -ret, buf );
+            polarssl_printf( " failed\n  !  x509_dn_gets returned -0x%02x - %s\n\n", -ret, buf );
             goto exit;
         }
 
         opt.subject_name = subject_name;
         subject_key = &csr.pk;
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
     }
 #endif /* POLARSSL_X509_CSR_PARSE_C */
 
@@ -465,7 +474,7 @@ int main( int argc, char *argv[] )
      */
     if( !opt.selfsign && !strlen( opt.request_file ) )
     {
-        printf( "  . Loading the subject key ..." );
+        polarssl_printf( "  . Loading the subject key ..." );
         fflush( stdout );
 
         ret = pk_parse_keyfile( &loaded_subject_key, opt.subject_key,
@@ -473,14 +482,14 @@ int main( int argc, char *argv[] )
         if( ret != 0 )
         {
             polarssl_strerror( ret, buf, 1024 );
-            printf( " failed\n  !  pk_parse_keyfile returned -0x%02x - %s\n\n", -ret, buf );
+            polarssl_printf( " failed\n  !  pk_parse_keyfile returned -0x%02x - %s\n\n", -ret, buf );
             goto exit;
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
     }
 
-    printf( "  . Loading the issuer key ..." );
+    polarssl_printf( "  . Loading the issuer key ..." );
     fflush( stdout );
 
     ret = pk_parse_keyfile( &loaded_issuer_key, opt.issuer_key,
@@ -488,7 +497,7 @@ int main( int argc, char *argv[] )
     if( ret != 0 )
     {
         polarssl_strerror( ret, buf, 1024 );
-        printf( " failed\n  !  pk_parse_keyfile returned -x%02x - %s\n\n", -ret, buf );
+        polarssl_printf( " failed\n  !  pk_parse_keyfile returned -x%02x - %s\n\n", -ret, buf );
         goto exit;
     }
 
@@ -502,13 +511,13 @@ int main( int argc, char *argv[] )
             mpi_cmp_mpi( &pk_rsa( issuer_crt.pk )->E,
                          &pk_rsa( *issuer_key )->E ) != 0 )
         {
-            printf( " failed\n  !  issuer_key does not match issuer certificate\n\n" );
+            polarssl_printf( " failed\n  !  issuer_key does not match issuer certificate\n\n" );
             ret = -1;
             goto exit;
         }
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     if( opt.selfsign )
     {
@@ -525,25 +534,25 @@ int main( int argc, char *argv[] )
     if( ( ret = x509write_crt_set_subject_name( &crt, opt.subject_name ) ) != 0 )
     {
         polarssl_strerror( ret, buf, 1024 );
-        printf( " failed\n  !  x509write_crt_set_subject_name returned -0x%02x - %s\n\n", -ret, buf );
+        polarssl_printf( " failed\n  !  x509write_crt_set_subject_name returned -0x%02x - %s\n\n", -ret, buf );
         goto exit;
     }
 
     if( ( ret = x509write_crt_set_issuer_name( &crt, opt.issuer_name ) ) != 0 )
     {
         polarssl_strerror( ret, buf, 1024 );
-        printf( " failed\n  !  x509write_crt_set_issuer_name returned -0x%02x - %s\n\n", -ret, buf );
+        polarssl_printf( " failed\n  !  x509write_crt_set_issuer_name returned -0x%02x - %s\n\n", -ret, buf );
         goto exit;
     }
 
-    printf( "  . Setting certificate values ..." );
+    polarssl_printf( "  . Setting certificate values ..." );
     fflush( stdout );
 
     ret = x509write_crt_set_serial( &crt, &serial );
     if( ret != 0 )
     {
         polarssl_strerror( ret, buf, 1024 );
-        printf( " failed\n  !  x509write_crt_set_serial returned -0x%02x - %s\n\n", -ret, buf );
+        polarssl_printf( " failed\n  !  x509write_crt_set_serial returned -0x%02x - %s\n\n", -ret, buf );
         goto exit;
     }
 
@@ -551,13 +560,13 @@ int main( int argc, char *argv[] )
     if( ret != 0 )
     {
         polarssl_strerror( ret, buf, 1024 );
-        printf( " failed\n  !  x509write_crt_set_validity returned -0x%02x - %s\n\n", -ret, buf );
+        polarssl_printf( " failed\n  !  x509write_crt_set_validity returned -0x%02x - %s\n\n", -ret, buf );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
-    printf( "  . Adding the Basic Constraints extension ..." );
+    polarssl_printf( "  . Adding the Basic Constraints extension ..." );
     fflush( stdout );
 
     ret = x509write_crt_set_basic_constraints( &crt, opt.is_ca,
@@ -565,87 +574,87 @@ int main( int argc, char *argv[] )
     if( ret != 0 )
     {
         polarssl_strerror( ret, buf, 1024 );
-        printf( " failed\n  !  x509write_crt_set_basic_contraints returned -0x%02x - %s\n\n", -ret, buf );
+        polarssl_printf( " failed\n  !  x509write_crt_set_basic_contraints returned -0x%02x - %s\n\n", -ret, buf );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
 #if defined(POLARSSL_SHA1_C)
-    printf( "  . Adding the Subject Key Identifier ..." );
+    polarssl_printf( "  . Adding the Subject Key Identifier ..." );
     fflush( stdout );
 
     ret = x509write_crt_set_subject_key_identifier( &crt );
     if( ret != 0 )
     {
         polarssl_strerror( ret, buf, 1024 );
-        printf( " failed\n  !  x509write_crt_set_subject_key_identifier returned -0x%02x - %s\n\n", -ret, buf );
+        polarssl_printf( " failed\n  !  x509write_crt_set_subject_key_identifier returned -0x%02x - %s\n\n", -ret, buf );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
-    printf( "  . Adding the Authority Key Identifier ..." );
+    polarssl_printf( "  . Adding the Authority Key Identifier ..." );
     fflush( stdout );
 
     ret = x509write_crt_set_authority_key_identifier( &crt );
     if( ret != 0 )
     {
         polarssl_strerror( ret, buf, 1024 );
-        printf( " failed\n  !  x509write_crt_set_authority_key_identifier returned -0x%02x - %s\n\n", -ret, buf );
+        polarssl_printf( " failed\n  !  x509write_crt_set_authority_key_identifier returned -0x%02x - %s\n\n", -ret, buf );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 #endif /* POLARSSL_SHA1_C */
 
     if( opt.key_usage )
     {
-        printf( "  . Adding the Key Usage extension ..." );
+        polarssl_printf( "  . Adding the Key Usage extension ..." );
         fflush( stdout );
 
         ret = x509write_crt_set_key_usage( &crt, opt.key_usage );
         if( ret != 0 )
         {
             polarssl_strerror( ret, buf, 1024 );
-            printf( " failed\n  !  x509write_crt_set_key_usage returned -0x%02x - %s\n\n", -ret, buf );
+            polarssl_printf( " failed\n  !  x509write_crt_set_key_usage returned -0x%02x - %s\n\n", -ret, buf );
             goto exit;
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
     }
 
     if( opt.ns_cert_type )
     {
-        printf( "  . Adding the NS Cert Type extension ..." );
+        polarssl_printf( "  . Adding the NS Cert Type extension ..." );
         fflush( stdout );
 
         ret = x509write_crt_set_ns_cert_type( &crt, opt.ns_cert_type );
         if( ret != 0 )
         {
             polarssl_strerror( ret, buf, 1024 );
-            printf( " failed\n  !  x509write_crt_set_ns_cert_type returned -0x%02x - %s\n\n", -ret, buf );
+            polarssl_printf( " failed\n  !  x509write_crt_set_ns_cert_type returned -0x%02x - %s\n\n", -ret, buf );
             goto exit;
         }
 
-        printf( " ok\n" );
+        polarssl_printf( " ok\n" );
     }
 
     /*
      * 1.2. Writing the request
      */
-    printf( "  . Writing the certificate..." );
+    polarssl_printf( "  . Writing the certificate..." );
     fflush( stdout );
 
     if( ( ret = write_certificate( &crt, opt.output_file,
                                    ctr_drbg_random, &ctr_drbg ) ) != 0 )
     {
         polarssl_strerror( ret, buf, 1024 );
-        printf( " failed\n  !  write_certifcate -0x%02x - %s\n\n", -ret, buf );
+        polarssl_printf( " failed\n  !  write_certifcate -0x%02x - %s\n\n", -ret, buf );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
 exit:
     x509write_crt_free( &crt );
@@ -656,7 +665,7 @@ exit:
     entropy_free( &entropy );
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/x509/crl_app.c
+++ b/programs/x509/crl_app.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -42,7 +51,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_RSA_C and/or "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_RSA_C and/or "
            "POLARSSL_X509_CRL_PARSE_C and/or POLARSSL_FS_IO not defined.\n");
     return( 0 );
 }
@@ -81,7 +90,7 @@ int main( int argc, char *argv[] )
     if( argc == 0 )
     {
     usage:
-        printf( USAGE );
+        polarssl_printf( USAGE );
         goto exit;
     }
 
@@ -103,39 +112,39 @@ int main( int argc, char *argv[] )
     /*
      * 1.1. Load the CRL
      */
-    printf( "\n  . Loading the CRL ..." );
+    polarssl_printf( "\n  . Loading the CRL ..." );
     fflush( stdout );
 
     ret = x509_crl_parse_file( &crl, opt.filename );
 
     if( ret != 0 )
     {
-        printf( " failed\n  !  x509_crl_parse_file returned %d\n\n", ret );
+        polarssl_printf( " failed\n  !  x509_crl_parse_file returned %d\n\n", ret );
         x509_crl_free( &crl );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 1.2 Print the CRL
      */
-    printf( "  . CRL information    ...\n" );
+    polarssl_printf( "  . CRL information    ...\n" );
     ret = x509_crl_info( (char *) buf, sizeof( buf ) - 1, "      ", &crl );
     if( ret == -1 )
     {
-        printf( " failed\n  !  x509_crl_info returned %d\n\n", ret );
+        polarssl_printf( " failed\n  !  x509_crl_info returned %d\n\n", ret );
         x509_crl_free( &crl );
         goto exit;
     }
 
-    printf( "%s\n", buf );
+    polarssl_printf( "%s\n", buf );
 
 exit:
     x509_crl_free( &crl );
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/programs/x509/req_app.c
+++ b/programs/x509/req_app.c
@@ -29,6 +29,15 @@
 #include POLARSSL_CONFIG_FILE
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
+#define polarssl_malloc     malloc
+#define polarssl_free       free
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -42,7 +51,7 @@ int main( int argc, char *argv[] )
     ((void) argc);
     ((void) argv);
 
-    printf("POLARSSL_BIGNUM_C and/or POLARSSL_RSA_C and/or "
+    polarssl_printf("POLARSSL_BIGNUM_C and/or POLARSSL_RSA_C and/or "
            "POLARSSL_X509_CSR_PARSE_C and/or POLARSSL_FS_IO not defined.\n");
     return( 0 );
 }
@@ -81,7 +90,7 @@ int main( int argc, char *argv[] )
     if( argc == 0 )
     {
     usage:
-        printf( USAGE );
+        polarssl_printf( USAGE );
         goto exit;
     }
 
@@ -103,39 +112,39 @@ int main( int argc, char *argv[] )
     /*
      * 1.1. Load the CSR
      */
-    printf( "\n  . Loading the CSR ..." );
+    polarssl_printf( "\n  . Loading the CSR ..." );
     fflush( stdout );
 
     ret = x509_csr_parse_file( &csr, opt.filename );
 
     if( ret != 0 )
     {
-        printf( " failed\n  !  x509_csr_parse_file returned %d\n\n", ret );
+        polarssl_printf( " failed\n  !  x509_csr_parse_file returned %d\n\n", ret );
         x509_csr_free( &csr );
         goto exit;
     }
 
-    printf( " ok\n" );
+    polarssl_printf( " ok\n" );
 
     /*
      * 1.2 Print the CSR
      */
-    printf( "  . CSR information    ...\n" );
+    polarssl_printf( "  . CSR information    ...\n" );
     ret = x509_csr_info( (char *) buf, sizeof( buf ) - 1, "      ", &csr );
     if( ret == -1 )
     {
-        printf( " failed\n  !  x509_csr_info returned %d\n\n", ret );
+        polarssl_printf( " failed\n  !  x509_csr_info returned %d\n\n", ret );
         x509_csr_free( &csr );
         goto exit;
     }
 
-    printf( "%s\n", buf );
+    polarssl_printf( "%s\n", buf );
 
 exit:
     x509_csr_free( &csr );
 
 #if defined(_WIN32)
-    printf( "  + Press Enter to exit this program.\n" );
+    polarssl_printf( "  + Press Enter to exit this program.\n" );
     fflush( stdout ); getchar();
 #endif
 

--- a/scripts/data_files/error.fmt
+++ b/scripts/data_files/error.fmt
@@ -33,6 +33,12 @@
 #include "polarssl/error.h"
 #endif
 
+#if defined(POLARSSL_PLATFORM_C)
+#include "polarssl/platform.h"
+#else
+#define polarssl_snprintf snprintf
+#endif
+
 #if defined(POLARSSL_ERROR_C)
 
 HEADER_INCLUDED
@@ -70,7 +76,7 @@ HIGH_LEVEL_CODE_CHECKS
         // END generated code
 
         if( strlen( buf ) == 0 )
-            snprintf( buf, buflen, "UNKNOWN ERROR CODE (%04X)", use_ret );
+            polarssl_snprintf( buf, buflen, "UNKNOWN ERROR CODE (%04X)", use_ret );
     }
 
     use_ret = ret & ~0xFF80;
@@ -88,7 +94,7 @@ HIGH_LEVEL_CODE_CHECKS
         if( buflen - len < 5 )
             return;
 
-        snprintf( buf + len, buflen - len, " : " );
+        polarssl_snprintf( buf + len, buflen - len, " : " );
 
         buf += len + 3;
         buflen -= len + 3;
@@ -103,7 +109,7 @@ LOW_LEVEL_CODE_CHECKS
     if( strlen( buf ) != 0 )
         return;
 
-    snprintf( buf, buflen, "UNKNOWN ERROR CODE (%04X)", use_ret );
+    polarssl_snprintf( buf, buflen, "UNKNOWN ERROR CODE (%04X)", use_ret );
 }
 
 #if defined(POLARSSL_ERROR_STRERROR_BC)

--- a/scripts/generate_errors.pl
+++ b/scripts/generate_errors.pl
@@ -143,14 +143,14 @@ while (my $line = <GREP>)
     {
         ${$code_check} .= "${white_space}if( use_ret == -($error_name) )\n".
                           "${white_space}\{\n".
-                          "${white_space}    snprintf( buf, buflen, \"$module_name - $description\" );\n".
+                          "${white_space}    polarssl_snprintf( buf, buflen, \"$module_name - $description\" );\n".
                           "${white_space}    return;\n".
                           "${white_space}}\n"
     }
     else
     {
         ${$code_check} .= "${white_space}if( use_ret == -($error_name) )\n".
-                          "${white_space}    snprintf( buf, buflen, \"$module_name - $description\" );\n"
+                          "${white_space}    polarssl_snprintf( buf, buflen, \"$module_name - $description\" );\n"
     }
 };
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -412,9 +412,9 @@ ifndef WINDOWS
 	do																		\
 		echo " - $${i}";													\
 		RESULT=`$(CHECK_PRELOAD) ./$${i} | grep -v 'PASS$$' | grep -v -- '----' | grep -v '^$$'`;	\
-		FAILED=`echo $$RESULT |grep FAILED`; 								\
+		PASSED=`echo $$RESULT |grep PASSED`; 								\
 		echo "   $$RESULT";													\
-		if [ "$$FAILED" != "" ];											\
+		if [ "$$PASSED" == "" ];											\
 		then																\
 			echo "**** Failed ***************";								\
 			RETURN=1;														\

--- a/tests/scripts/generate_code.pl
+++ b/tests/scripts/generate_code.pl
@@ -6,11 +6,11 @@ use strict;
 my $suite_dir = shift or die "Missing suite directory";
 my $suite_name = shift or die "Missing suite name";
 my $data_name = shift or die "Missing data name";
+my $test_main_file = do { my $arg = shift; defined($arg) ? $arg :  $suite_dir."/main_test.function" };
 my $test_file = $data_name.".c";
 my $test_helper_file = $suite_dir."/helpers.function";
 my $test_case_file = $suite_dir."/".$suite_name.".function";
 my $test_case_data = $suite_dir."/".$data_name.".data";
-my $test_main_file = $suite_dir."/main_test.function";
 
 my $line_separator = $/;
 undef $/;

--- a/tests/scripts/generate_code.pl
+++ b/tests/scripts/generate_code.pl
@@ -172,7 +172,7 @@ $function_pre_code
 $param_defs
     if( cnt != $param_count )
     {
-        fprintf( stderr, "\\nIncorrect argument count (%d != %d)\\n", cnt, $param_count );
+        polarssl_fprintf( stderr, "\\nIncorrect argument count (%d != %d)\\n", cnt, $param_count );
         return( 2 );
     }
 

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -83,14 +83,14 @@ static int unhexify( unsigned char *obuf, const char *ibuf )
     return len;
 }
 
-static void hexify(unsigned char *obuf, const unsigned char *ibuf, int len)
+static void hexify( unsigned char *obuf, const unsigned char *ibuf, int len )
 {
     unsigned char l, h;
 
-    while (len != 0)
+    while( len != 0 )
     {
-        h = (*ibuf) / 16;
-        l = (*ibuf) % 16;
+        h = *ibuf / 16;
+        l = *ibuf % 16;
 
         if( h < 10 )
             *obuf++ = '0' + h;
@@ -117,7 +117,7 @@ static void hexify(unsigned char *obuf, const unsigned char *ibuf, int len)
 static unsigned char *zero_alloc( size_t len )
 {
     void *p;
-    size_t actual_len = len != 0 ? len : 1;
+    size_t actual_len = ( len != 0 ) ? len : 1;
 
     p = polarssl_malloc( actual_len );
     assert( p != NULL );
@@ -141,7 +141,7 @@ static unsigned char *unhexify_alloc( const char *ibuf, size_t *olen )
 {
     unsigned char *obuf;
 
-    *olen = strlen(ibuf) / 2;
+    *olen = strlen( ibuf ) / 2;
 
     if( *olen == 0 )
         return( zero_alloc( *olen ) );
@@ -279,9 +279,11 @@ static int rnd_pseudo_rand( void *rng_state, unsigned char *output, size_t len )
 
         for( i = 0; i < 32; i++ )
         {
-            info->v0 += (((info->v1 << 4) ^ (info->v1 >> 5)) + info->v1) ^ (sum + k[sum & 3]);
+            info->v0 += ( ( ( info->v1 << 4 ) ^ ( info->v1 >> 5 ) )
+                            + info->v1 ) ^ ( sum + k[sum & 3] );
             sum += delta;
-            info->v1 += (((info->v0 << 4) ^ (info->v0 >> 5)) + info->v0) ^ (sum + k[(sum>>11) & 3]);
+            info->v1 += ( ( ( info->v0 << 4 ) ^ ( info->v0 >> 5 ) )
+                            + info->v0 ) ^ ( sum + k[( sum>>11 ) & 3] );
         }
 
         PUT_UINT32_BE( info->v0, result, 0 );

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -47,7 +47,7 @@ static int unhexify(unsigned char *obuf, const char *ibuf)
 {
     unsigned char c, c2;
     int len = strlen(ibuf) / 2;
-    assert(!(strlen(ibuf) %1)); // must be even number of bytes
+    assert( strlen(ibuf) % 2 == 0 ); // must be even number of bytes
 
     while (*ibuf != 0)
     {

--- a/tests/suites/helpers.function
+++ b/tests/suites/helpers.function
@@ -16,9 +16,15 @@ typedef UINT32 uint32_t;
 #include <inttypes.h>
 #endif
 
-#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
+
+#define assert(a) if( !( a ) )                                      \
+{                                                                   \
+    polarssl_fprintf( stderr, "Assertion Failed at %s:%d - %s\n",   \
+                             __FILE__, __LINE__, #a );              \
+    polarssl_exit( 1 );                                             \
+}
 
 /*
  * 32-bit integer manipulation macros (big endian)
@@ -43,13 +49,13 @@ typedef UINT32 uint32_t;
 }
 #endif
 
-static int unhexify(unsigned char *obuf, const char *ibuf)
+static int unhexify( unsigned char *obuf, const char *ibuf )
 {
     unsigned char c, c2;
-    int len = strlen(ibuf) / 2;
-    assert( strlen(ibuf) % 2 == 0 ); // must be even number of bytes
+    int len = strlen( ibuf ) / 2;
+    assert( strlen( ibuf ) % 2 == 0 ); // must be even number of bytes
 
-    while (*ibuf != 0)
+    while( *ibuf != 0 )
     {
         c = *ibuf++;
         if( c >= '0' && c <= '9' )

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -8,6 +8,7 @@
 #define polarssl_fprintf    fprintf
 #define polarssl_malloc     malloc
 #define polarssl_free       free
+#define polarssl_exit       exit
 #endif
 
 static int test_errors = 0;
@@ -275,7 +276,7 @@ int main()
         {
             polarssl_fprintf( stderr, "FAILED: FATAL PARSE ERROR\n" );
             fclose(file);
-            exit( 2 );
+            polarssl_exit( 2 );
         }
         else
             total_errors++;

--- a/tests/suites/main_test.function
+++ b/tests/suites/main_test.function
@@ -5,6 +5,7 @@
 #include "polarssl/platform.h"
 #else
 #define polarssl_printf     printf
+#define polarssl_fprintf    fprintf
 #define polarssl_malloc     malloc
 #define polarssl_free       free
 #endif
@@ -21,8 +22,8 @@ static int test_assert( int correct, const char *test )
 
     test_errors++;
     if( test_errors == 1 )
-        printf( "FAILED\n" );
-    printf( "  %s\n", test );
+        polarssl_printf( "FAILED\n" );
+    polarssl_printf( "  %s\n", test );
 
     return( 1 );
 }
@@ -37,7 +38,7 @@ int verify_string( char **str )
     if( (*str)[0] != '"' ||
         (*str)[strlen( *str ) - 1] != '"' )
     {
-        printf( "Expected string (with \"\") for parameter and got: %s\n", *str );
+        polarssl_printf( "Expected string (with \"\") for parameter and got: %s\n", *str );
         return( -1 );
     }
 
@@ -90,7 +91,7 @@ int verify_int( char *str, int *value )
 
 MAPPING_CODE
 
-    printf( "Expected integer for parameter and got: %s\n", str );
+    polarssl_printf( "Expected integer for parameter and got: %s\n", str );
     return( -1 );
 }
 
@@ -116,7 +117,7 @@ int dispatch_test(int cnt, char *params[50])
 #if defined(TEST_SUITE_ACTIVE)
 DISPATCH_FUNCTION
     {
-        fprintf( stdout, "FAILED\nSkipping unknown test function '%s'\n", params[0] );
+        polarssl_fprintf( stdout, "FAILED\nSkipping unknown test function '%s'\n", params[0] );
         fflush( stdout );
         return( 1 );
     }
@@ -219,7 +220,7 @@ int main()
     file = fopen( filename, "r" );
     if( file == NULL )
     {
-        fprintf( stderr, "Failed to open\n" );
+        polarssl_fprintf( stderr, "Failed to open\n" );
         return( 1 );
     }
 
@@ -229,11 +230,11 @@ int main()
 
         if( ( ret = get_line( file, buf, sizeof(buf) ) ) != 0 )
             break;
-        fprintf( stdout, "%s%.66s", test_errors ? "\n" : "", buf );
-        fprintf( stdout, " " );
+        polarssl_fprintf( stdout, "%s%.66s", test_errors ? "\n" : "", buf );
+        polarssl_fprintf( stdout, " " );
         for( i = strlen( buf ) + 1; i < 67; i++ )
-            fprintf( stdout, "." );
-        fprintf( stdout, " " );
+            polarssl_fprintf( stdout, "." );
+        polarssl_fprintf( stdout, " " );
         fflush( stdout );
 
         total_tests++;
@@ -262,17 +263,17 @@ int main()
         if( skip == 1 || ret == 3 )
         {
             total_skipped++;
-            fprintf( stdout, "----\n" );
+            polarssl_fprintf( stdout, "----\n" );
             fflush( stdout );
         }
         else if( ret == 0 && test_errors == 0 )
         {
-            fprintf( stdout, "PASS\n" );
+            polarssl_fprintf( stdout, "PASS\n" );
             fflush( stdout );
         }
         else if( ret == 2 )
         {
-            fprintf( stderr, "FAILED: FATAL PARSE ERROR\n" );
+            polarssl_fprintf( stderr, "FAILED: FATAL PARSE ERROR\n" );
             fclose(file);
             exit( 2 );
         }
@@ -283,19 +284,19 @@ int main()
             break;
         if( strlen(buf) != 0 )
         {
-            fprintf( stderr, "Should be empty %d\n", (int) strlen(buf) );
+            polarssl_fprintf( stderr, "Should be empty %d\n", (int) strlen(buf) );
             return( 1 );
         }
     }
     fclose(file);
 
-    fprintf( stdout, "\n----------------------------------------------------------------------------\n\n");
+    polarssl_fprintf( stdout, "\n----------------------------------------------------------------------------\n\n");
     if( total_errors == 0 )
-        fprintf( stdout, "PASSED" );
+        polarssl_fprintf( stdout, "PASSED" );
     else
-        fprintf( stdout, "FAILED" );
+        polarssl_fprintf( stdout, "FAILED" );
 
-    fprintf( stdout, " (%d / %d tests (%d skipped))\n",
+    polarssl_fprintf( stdout, " (%d / %d tests (%d skipped))\n",
              total_tests - total_errors, total_tests, total_skipped );
 
 #if defined(POLARSSL_MEMORY_BUFFER_ALLOC_C)

--- a/tests/suites/test_suite_version.function
+++ b/tests/suites/test_suite_version.function
@@ -17,10 +17,10 @@ void check_compiletime_version( char *version_str )
     memset( build_str, 0, 100 );
     memset( build_str_full, 0, 100 );
 
-    snprintf (build_str, 100, "%d.%d.%d", POLARSSL_VERSION_MAJOR,
+    polarssl_snprintf (build_str, 100, "%d.%d.%d", POLARSSL_VERSION_MAJOR,
         POLARSSL_VERSION_MINOR, POLARSSL_VERSION_PATCH );
 
-    snprintf( build_str_full, 100, "PolarSSL %d.%d.%d", POLARSSL_VERSION_MAJOR,
+    polarssl_snprintf( build_str_full, 100, "PolarSSL %d.%d.%d", POLARSSL_VERSION_MAJOR,
         POLARSSL_VERSION_MINOR, POLARSSL_VERSION_PATCH );
 
     build_int = POLARSSL_VERSION_MAJOR << 24 |
@@ -52,11 +52,11 @@ void check_runtime_version( char *version_str )
     version_get_string( get_str );
     version_get_string_full( get_str_full );
 
-    snprintf( build_str, 100, "%d.%d.%d",
+    polarssl_snprintf( build_str, 100, "%d.%d.%d",
         (get_int >> 24) & 0xFF,
         (get_int >> 16) & 0xFF,
         (get_int >> 8) & 0xFF );
-    snprintf( build_str_full, 100, "PolarSSL %s", version_str );
+    polarssl_snprintf( build_str_full, 100, "PolarSSL %s", version_str );
 
     TEST_ASSERT( strcmp( build_str, version_str ) == 0 );
     TEST_ASSERT( strcmp( build_str_full, get_str_full ) == 0 );

--- a/tests/suites/test_suite_x509parse.function
+++ b/tests/suites/test_suite_x509parse.function
@@ -445,7 +445,7 @@ void x509_parse_rsassa_pss_params( char *hex_params, int params_tag,
     my_ret = x509_get_rsassa_pss_params( &params, &my_msg_md, &my_mgf_md,
                                          &my_salt_len );
 
-    if( my_ret != ref_ret ) printf( "\n%04X\n", - my_ret );
+    if( my_ret != ref_ret ) polarssl_printf( "\n%04X\n", - my_ret );
 
     TEST_ASSERT( my_ret == ref_ret );
 


### PR DESCRIPTION
Added the ability to define own implementation of snprintf and exit for use in embedded systems.  Removed dependency on sscanf which in turn depended on malloc, breaking the point of being able to specify non std memory functions.