### PR TITLE
build: make: support windows cross compile

### DIFF
--- a/library/Makefile
+++ b/library/Makefile
@@ -22,14 +22,22 @@ ifdef SHARED
 CFLAGS += -fPIC
 endif
 
-SONAME=libmbedtls.so.7
+SOEXT=so.8
 
-DLEXT=so.8
+DLEXT=so
 # OSX shared library extension:
 # DLEXT=dylib
 
-# Windows shared library extension:
+#
+# if we running on Windows build
+# for Windows
+#
 ifdef WINDOWS
+WINDOWS_BUILD=1
+endif
+
+# Windows shared library extension:
+ifdef WINDOWS_BUILD
 DLEXT=dll
 LDFLAGS += -lws2_32
 endif
@@ -73,7 +81,7 @@ endif
 
 static: libpolarssl.a
 
-shared: libpolarssl.so
+shared: libpolarssl.$(DLEXT)
 
 libpolarssl.a: libmbedtls.a
 	echo "  LN    $@ -> $?"
@@ -89,21 +97,28 @@ libmbedtls.a: $(OBJS)
 	echo "  RL    $@"
 	$(AR) s $@
 
-libpolarssl.so: libmbedtls.so
+libpolarssl.$(DLEXT): libmbedtls.$(DLEXT)
 	echo "  LN    $@ -> $?"
 ifndef WINDOWS
 	ln -sf $? $@
 else
 	copy /y /b $? $@
 endif
+ifdef WINDOWS_BUILD
+ifndef WINDOWS
+	ln -sf $?.a $@.a
+else
+	copy /y /b $?.a $@.a
+endif
+endif
 
-libmbedtls.${DLEXT}: $(OBJS)
+libmbedtls.$(SOEXT): $(OBJS)
 	echo "  LD    $@"
-	$(CC) ${LDFLAGS} -shared -Wl,-soname,$(SONAME) -o $@ $(OBJS)
+	$(CC) ${LDFLAGS} -shared -Wl,-soname,$@ -o $@ $(OBJS)
 
-libmbedtls.so: libmbedtls.${DLEXT}
-	echo "  LN    $@ -> libmbedtls.${DLEXT}"
-	ln -sf libmbedtls.${DLEXT} $@
+libmbedtls.so: libmbedtls.$(SOEXT)
+	echo "  LN    $@ -> libmbedtls.$(SOEXT)"
+	ln -sf libmbedtls.$(SOEXT) $@
 
 libmbedtls.dylib: $(OBJS)
 	echo "  LD    $@"
@@ -111,7 +126,7 @@ libmbedtls.dylib: $(OBJS)
 
 libmbedtls.dll: $(OBJS)
 	echo "  LD    $@"
-	$(CC) -shared -Wl,-soname,$@ -o $@ $(OBJS) -lws2_32 -lwinmm -lgdi32
+	$(CC) -shared -Wl,-soname,$@ -Wl,--out-implib,$@.a -o $@ $(OBJS) -lws2_32 -lwinmm -lgdi32
 
 .c.o:
 	echo "  CC    $<"

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -5,14 +5,27 @@
 
 CFLAGS	+= -I../include -D_FILE_OFFSET_BITS=64 -Wall -W -Wdeclaration-after-statement
 OFLAGS	= -O2
-LDFLAGS	+= -L../library -lmbedtls $(SYS_LDFLAGS)
+LDFLAGS	+= -L../library -lmbedtls$(SHARED_SUFFIX) $(SYS_LDFLAGS)
 
 ifdef DEBUG
 CFLAGS += -g3
 endif
 
+#
+# if we running on Windows build
+# for Windows
+#
 ifdef WINDOWS
+WINDOWS_BUILD=1
+endif
+
+ifdef WINDOWS_BUILD
+DLEXT=dll
+EXEXT=.exe
 LDFLAGS += -lws2_32
+ifdef SHARED
+SHARED_SUFFIX=.$(DLEXT)
+endif
 endif
 
 # Zlib shared library extensions:
@@ -20,30 +33,30 @@ ifdef ZLIB
 LDFLAGS += -lz
 endif
 
-APPS =	aes/aescrypt2	aes/crypt_and_hash	\
-	hash/hello			hash/generic_sum	\
-	hash/md5sum			hash/sha1sum		\
-	hash/sha2sum		pkey/dh_client		\
-	pkey/dh_genprime	pkey/dh_server		\
-	pkey/gen_key							\
-	pkey/key_app		pkey/key_app_writer	\
-	pkey/mpi_demo		pkey/pk_decrypt		\
-	pkey/pk_encrypt		pkey/pk_sign		\
-	pkey/pk_verify		pkey/rsa_genkey		\
-	pkey/rsa_decrypt	pkey/rsa_encrypt	\
-	pkey/rsa_sign		pkey/rsa_verify		\
-	pkey/rsa_sign_pss	pkey/rsa_verify_pss \
-	ssl/ssl_client1		ssl/ssl_client2		\
-	ssl/ssl_server		ssl/ssl_server2		\
-	ssl/ssl_fork_server						\
-	ssl/ssl_mail_client	random/gen_entropy	\
-	random/gen_random_havege				\
-	random/gen_random_ctr_drbg				\
-	test/ssl_cert_test	test/benchmark		\
-	test/selftest		test/ssl_test		\
-	util/pem2der		util/strerror		\
-	x509/cert_app		x509/crl_app		\
-	x509/cert_req
+APPS =	aes/aescrypt2$(EXEXT)		aes/crypt_and_hash$(EXEXT)	\
+	hash/hello$(EXEXT)		hash/generic_sum$(EXEXT)	\
+	hash/md5sum$(EXEXT)		hash/sha1sum$(EXEXT)		\
+	hash/sha2sum$(EXEXT)		pkey/dh_client$(EXEXT)		\
+	pkey/dh_genprime$(EXEXT)	pkey/dh_server$(EXEXT)		\
+	pkey/gen_key$(EXEXT)						\
+	pkey/key_app$(EXEXT)		pkey/key_app_writer$(EXEXT)	\
+	pkey/mpi_demo$(EXEXT)		pkey/pk_decrypt$(EXEXT)		\
+	pkey/pk_encrypt$(EXEXT)		pkey/pk_sign$(EXEXT)		\
+	pkey/pk_verify$(EXEXT)		pkey/rsa_genkey$(EXEXT)		\
+	pkey/rsa_decrypt$(EXEXT)	pkey/rsa_encrypt$(EXEXT)	\
+	pkey/rsa_sign$(EXEXT)		pkey/rsa_verify$(EXEXT)		\
+	pkey/rsa_sign_pss$(EXEXT)	pkey/rsa_verify_pss$(EXEXT)	\
+	ssl/ssl_client1$(EXEXT)		ssl/ssl_client2$(EXEXT)		\
+	ssl/ssl_server$(EXEXT)		ssl/ssl_server2$(EXEXT)		\
+	ssl/ssl_fork_server$(EXEXT)					\
+	ssl/ssl_mail_client$(EXEXT)	random/gen_entropy$(EXEXT)	\
+	random/gen_random_havege$(EXEXT)				\
+	random/gen_random_ctr_drbg$(EXEXT)				\
+	test/ssl_cert_test$(EXEXT)	test/benchmark$(EXEXT)		\
+	test/selftest$(EXEXT)		test/ssl_test$(EXEXT)		\
+	util/pem2der$(EXEXT)		util/strerror$(EXEXT)		\
+	x509/cert_app$(EXEXT)		x509/crl_app$(EXEXT)		\
+	x509/cert_req$(EXEXT)
 
 ifdef OPENSSL
 APPS +=	test/o_p_test
@@ -57,187 +70,187 @@ endif
 
 all: $(APPS)
 
-aes/aescrypt2: aes/aescrypt2.c ../library/libmbedtls.a
+aes/aescrypt2$(EXEXT): aes/aescrypt2.c ../library/libmbedtls.a
 	echo   "  CC    aes/aescrypt2.c"
 	$(CC) $(CFLAGS) $(OFLAGS) aes/aescrypt2.c    $(LDFLAGS) -o $@
 
-aes/crypt_and_hash: aes/crypt_and_hash.c ../library/libmbedtls.a
+aes/crypt_and_hash$(EXEXT): aes/crypt_and_hash.c ../library/libmbedtls.a
 	echo   "  CC    aes/crypt_and_hash.c"
 	$(CC) $(CFLAGS) $(OFLAGS) aes/crypt_and_hash.c $(LDFLAGS) -o $@
 
-hash/hello: hash/hello.c ../library/libmbedtls.a
+hash/hello$(EXEXT): hash/hello.c ../library/libmbedtls.a
 	echo   "  CC    hash/hello.c"
 	$(CC) $(CFLAGS) $(OFLAGS) hash/hello.c       $(LDFLAGS) -o $@
 
-hash/generic_sum: hash/generic_sum.c ../library/libmbedtls.a
+hash/generic_sum$(EXEXT): hash/generic_sum.c ../library/libmbedtls.a
 	echo   "  CC    hash/generic_sum.c"
 	$(CC) $(CFLAGS) $(OFLAGS) hash/generic_sum.c $(LDFLAGS) -o $@
 
-hash/md5sum: hash/md5sum.c ../library/libmbedtls.a
+hash/md5sum$(EXEXT): hash/md5sum.c ../library/libmbedtls.a
 	echo   "  CC    hash/md5sum.c"
 	$(CC) $(CFLAGS) $(OFLAGS) hash/md5sum.c      $(LDFLAGS) -o $@
 
-hash/sha1sum: hash/sha1sum.c ../library/libmbedtls.a
+hash/sha1sum$(EXEXT): hash/sha1sum.c ../library/libmbedtls.a
 	echo   "  CC    hash/sha1sum.c"
 	$(CC) $(CFLAGS) $(OFLAGS) hash/sha1sum.c     $(LDFLAGS) -o $@
 
-hash/sha2sum: hash/sha2sum.c ../library/libmbedtls.a
+hash/sha2sum$(EXEXT): hash/sha2sum.c ../library/libmbedtls.a
 	echo   "  CC    hash/sha2sum.c"
 	$(CC) $(CFLAGS) $(OFLAGS) hash/sha2sum.c     $(LDFLAGS) -o $@
 
-pkey/dh_client: pkey/dh_client.c ../library/libmbedtls.a
+pkey/dh_client$(EXEXT): pkey/dh_client.c ../library/libmbedtls.a
 	echo   "  CC    pkey/dh_client.c"
 	$(CC) $(CFLAGS) $(OFLAGS) pkey/dh_client.c   $(LDFLAGS) -o $@
 
-pkey/dh_genprime: pkey/dh_genprime.c ../library/libmbedtls.a
+pkey/dh_genprime$(EXEXT): pkey/dh_genprime.c ../library/libmbedtls.a
 	echo   "  CC    pkey/dh_genprime.c"
 	$(CC) $(CFLAGS) $(OFLAGS) pkey/dh_genprime.c $(LDFLAGS) -o $@
 
-pkey/dh_server: pkey/dh_server.c ../library/libmbedtls.a
+pkey/dh_server$(EXEXT): pkey/dh_server.c ../library/libmbedtls.a
 	echo   "  CC    pkey/dh_server.c"
 	$(CC) $(CFLAGS) $(OFLAGS) pkey/dh_server.c   $(LDFLAGS) -o $@
 
-pkey/ecdsa: pkey/ecdsa.c ../library/libmbedtls.a
+pkey/ecdsa$(EXEXT): pkey/ecdsa.c ../library/libmbedtls.a
 	echo   "  CC    pkey/ecdsa.c"
 	$(CC) $(CFLAGS) $(OFLAGS) pkey/ecdsa.c       $(LDFLAGS) -o $@
 
-pkey/gen_key: pkey/gen_key.c ../library/libmbedtls.a
+pkey/gen_key$(EXEXT): pkey/gen_key.c ../library/libmbedtls.a
 	echo   "  CC    pkey/gen_key.c"
 	$(CC) $(CFLAGS) $(OFLAGS) pkey/gen_key.c   $(LDFLAGS) -o $@
 
-pkey/key_app: pkey/key_app.c ../library/libmbedtls.a
+pkey/key_app$(EXEXT): pkey/key_app.c ../library/libmbedtls.a
 	echo   "  CC    pkey/key_app.c"
 	$(CC) $(CFLAGS) $(OFLAGS) pkey/key_app.c   $(LDFLAGS) -o $@
 
-pkey/key_app_writer: pkey/key_app_writer.c ../library/libmbedtls.a
+pkey/key_app_writer$(EXEXT): pkey/key_app_writer.c ../library/libmbedtls.a
 	echo   "  CC    pkey/key_app_writer.c"
 	$(CC) $(CFLAGS) $(OFLAGS) pkey/key_app_writer.c   $(LDFLAGS) -o $@
 
-pkey/mpi_demo: pkey/mpi_demo.c ../library/libmbedtls.a
+pkey/mpi_demo$(EXEXT): pkey/mpi_demo.c ../library/libmbedtls.a
 	echo   "  CC    pkey/mpi_demo.c"
 	$(CC) $(CFLAGS) $(OFLAGS) pkey/mpi_demo.c    $(LDFLAGS) -o $@
 
-pkey/pk_decrypt: pkey/pk_decrypt.c ../library/libmbedtls.a
+pkey/pk_decrypt$(EXEXT): pkey/pk_decrypt.c ../library/libmbedtls.a
 	echo   "  CC    pkey/pk_decrypt.c"
 	$(CC) $(CFLAGS) $(OFLAGS) pkey/pk_decrypt.c    $(LDFLAGS) -o $@
 
-pkey/pk_encrypt: pkey/pk_encrypt.c ../library/libmbedtls.a
+pkey/pk_encrypt$(EXEXT): pkey/pk_encrypt.c ../library/libmbedtls.a
 	echo   "  CC    pkey/pk_encrypt.c"
 	$(CC) $(CFLAGS) $(OFLAGS) pkey/pk_encrypt.c    $(LDFLAGS) -o $@
 
-pkey/pk_sign: pkey/pk_sign.c ../library/libmbedtls.a
+pkey/pk_sign$(EXEXT): pkey/pk_sign.c ../library/libmbedtls.a
 	echo   "  CC    pkey/pk_sign.c"
 	$(CC) $(CFLAGS) $(OFLAGS) pkey/pk_sign.c    $(LDFLAGS) -o $@
 
-pkey/pk_verify: pkey/pk_verify.c ../library/libmbedtls.a
+pkey/pk_verify$(EXEXT): pkey/pk_verify.c ../library/libmbedtls.a
 	echo   "  CC    pkey/pk_verify.c"
 	$(CC) $(CFLAGS) $(OFLAGS) pkey/pk_verify.c  $(LDFLAGS) -o $@
 
-pkey/rsa_genkey: pkey/rsa_genkey.c ../library/libmbedtls.a
+pkey/rsa_genkey$(EXEXT): pkey/rsa_genkey.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_genkey.c"
 	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_genkey.c  $(LDFLAGS) -o $@
 
-pkey/rsa_sign: pkey/rsa_sign.c ../library/libmbedtls.a
+pkey/rsa_sign$(EXEXT): pkey/rsa_sign.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_sign.c"
 	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_sign.c    $(LDFLAGS) -o $@
 
-pkey/rsa_verify: pkey/rsa_verify.c ../library/libmbedtls.a
+pkey/rsa_verify$(EXEXT): pkey/rsa_verify.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_verify.c"
 	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_verify.c  $(LDFLAGS) -o $@
 
-pkey/rsa_sign_pss: pkey/rsa_sign_pss.c ../library/libmbedtls.a
+pkey/rsa_sign_pss$(EXEXT): pkey/rsa_sign_pss.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_sign_pss.c"
 	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_sign_pss.c    $(LDFLAGS) -o $@
 
-pkey/rsa_verify_pss: pkey/rsa_verify_pss.c ../library/libmbedtls.a
+pkey/rsa_verify_pss$(EXEXT): pkey/rsa_verify_pss.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_verify_pss.c"
 	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_verify_pss.c  $(LDFLAGS) -o $@
 
-pkey/rsa_decrypt: pkey/rsa_decrypt.c ../library/libmbedtls.a
+pkey/rsa_decrypt$(EXEXT): pkey/rsa_decrypt.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_decrypt.c"
 	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_decrypt.c    $(LDFLAGS) -o $@
 
-pkey/rsa_encrypt: pkey/rsa_encrypt.c ../library/libmbedtls.a
+pkey/rsa_encrypt$(EXEXT): pkey/rsa_encrypt.c ../library/libmbedtls.a
 	echo   "  CC    pkey/rsa_encrypt.c"
 	$(CC) $(CFLAGS) $(OFLAGS) pkey/rsa_encrypt.c    $(LDFLAGS) -o $@
 
-random/gen_entropy: random/gen_entropy.c ../library/libmbedtls.a
+random/gen_entropy$(EXEXT): random/gen_entropy.c ../library/libmbedtls.a
 	echo   "  CC    random/gen_entropy.c"
 	$(CC) $(CFLAGS) $(OFLAGS) random/gen_entropy.c $(LDFLAGS) -o $@
 
-random/gen_random_havege: random/gen_random_havege.c ../library/libmbedtls.a
+random/gen_random_havege$(EXEXT): random/gen_random_havege.c ../library/libmbedtls.a
 	echo   "  CC    random/gen_random_havege.c"
 	$(CC) $(CFLAGS) $(OFLAGS) random/gen_random_havege.c $(LDFLAGS) -o $@
 
-random/gen_random_ctr_drbg: random/gen_random_ctr_drbg.c ../library/libmbedtls.a
+random/gen_random_ctr_drbg$(EXEXT): random/gen_random_ctr_drbg.c ../library/libmbedtls.a
 	echo   "  CC    random/gen_random_ctr_drbg.c"
 	$(CC) $(CFLAGS) $(OFLAGS) random/gen_random_ctr_drbg.c $(LDFLAGS) -o $@
 
-ssl/ssl_client1: ssl/ssl_client1.c ../library/libmbedtls.a
+ssl/ssl_client1$(EXEXT): ssl/ssl_client1.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_client1.c"
 	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_client1.c  $(LDFLAGS) -o $@
 
-ssl/ssl_client2: ssl/ssl_client2.c ../library/libmbedtls.a
+ssl/ssl_client2$(EXEXT): ssl/ssl_client2.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_client2.c"
 	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_client2.c  $(LDFLAGS) -o $@
 
-ssl/ssl_server: ssl/ssl_server.c ../library/libmbedtls.a
+ssl/ssl_server$(EXEXT): ssl/ssl_server.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_server.c"
 	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_server.c   $(LDFLAGS) -o $@
 
-ssl/ssl_server2: ssl/ssl_server2.c ../library/libmbedtls.a
+ssl/ssl_server2$(EXEXT): ssl/ssl_server2.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_server2.c"
 	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_server2.c   $(LDFLAGS) -o $@
 
-ssl/ssl_fork_server: ssl/ssl_fork_server.c ../library/libmbedtls.a
+ssl/ssl_fork_server$(EXEXT): ssl/ssl_fork_server.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_fork_server.c"
 	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_fork_server.c   $(LDFLAGS) -o $@
 
-ssl/ssl_pthread_server: ssl/ssl_pthread_server.c ../library/libmbedtls.a
+ssl/ssl_pthread_server$(EXEXT): ssl/ssl_pthread_server.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_pthread_server.c"
 	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_pthread_server.c   $(LDFLAGS) -o $@ -lpthread
 
-ssl/ssl_mail_client: ssl/ssl_mail_client.c ../library/libmbedtls.a
+ssl/ssl_mail_client$(EXEXT): ssl/ssl_mail_client.c ../library/libmbedtls.a
 	echo   "  CC    ssl/ssl_mail_client.c"
 	$(CC) $(CFLAGS) $(OFLAGS) ssl/ssl_mail_client.c   $(LDFLAGS) -o $@
 
-test/ssl_cert_test: test/ssl_cert_test.c ../library/libmbedtls.a
+test/ssl_cert_test$(EXEXT): test/ssl_cert_test.c ../library/libmbedtls.a
 	echo   "  CC    test/ssl_cert_test.c"
 	$(CC) $(CFLAGS) $(OFLAGS) test/ssl_cert_test.c   $(LDFLAGS) -o $@
 
-test/benchmark: test/benchmark.c ../library/libmbedtls.a
+test/benchmark$(EXEXT): test/benchmark.c ../library/libmbedtls.a
 	echo   "  CC    test/benchmark.c"
 	$(CC) $(CFLAGS) $(OFLAGS) test/benchmark.c   $(LDFLAGS) -o $@
 
-test/selftest: test/selftest.c ../library/libmbedtls.a
+test/selftest$(EXEXT): test/selftest.c ../library/libmbedtls.a
 	echo   "  CC    test/selftest.c"
 	$(CC) $(CFLAGS) $(OFLAGS) test/selftest.c    $(LDFLAGS) -o $@
 
-test/ssl_test: test/ssl_test.c ../library/libmbedtls.a
+test/ssl_test$(EXEXT): test/ssl_test.c ../library/libmbedtls.a
 	echo   "  CC    test/ssl_test.c"
 	$(CC) $(CFLAGS) $(OFLAGS) test/ssl_test.c    $(LDFLAGS) -o $@
 
-test/o_p_test: test/o_p_test.c ../library/libmbedtls.a
+test/o_p_test$(EXEXT): test/o_p_test.c ../library/libmbedtls.a
 	echo   "  CC    test/o_p_test.c"
 	$(CC) $(CFLAGS) $(OFLAGS) test/o_p_test.c    $(LDFLAGS) -o $@ -lssl -lcrypto
 
-util/pem2der: util/pem2der.c ../library/libmbedtls.a
+util/pem2der$(EXEXT): util/pem2der.c ../library/libmbedtls.a
 	echo   "  CC    util/pem2der.c"
 	$(CC) $(CFLAGS) $(OFLAGS) util/pem2der.c    $(LDFLAGS) -o $@
 
-util/strerror: util/strerror.c ../library/libmbedtls.a
+util/strerror$(EXEXT): util/strerror.c ../library/libmbedtls.a
 	echo   "  CC    util/strerror.c"
 	$(CC) $(CFLAGS) $(OFLAGS) util/strerror.c    $(LDFLAGS) -o $@
 
-x509/cert_app: x509/cert_app.c ../library/libmbedtls.a
+x509/cert_app$(EXEXT): x509/cert_app.c ../library/libmbedtls.a
 	echo   "  CC    x509/cert_app.c"
 	$(CC) $(CFLAGS) $(OFLAGS) x509/cert_app.c    $(LDFLAGS) -o $@
 
-x509/crl_app: x509/crl_app.c ../library/libmbedtls.a
+x509/crl_app$(EXEXT): x509/crl_app.c ../library/libmbedtls.a
 	echo   "  CC    x509/crl_app.c"
 	$(CC) $(CFLAGS) $(OFLAGS) x509/crl_app.c    $(LDFLAGS) -o $@
 
-x509/cert_req: x509/cert_req.c ../library/libmbedtls.a
+x509/cert_req$(EXEXT): x509/cert_req.c ../library/libmbedtls.a
 	echo   "  CC    x509/cert_req.c"
 	$(CC) $(CFLAGS) $(OFLAGS) x509/cert_req.c    $(LDFLAGS) -o $@
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -7,22 +7,36 @@ CFLAGS	+= -I../include -D_FILE_OFFSET_BITS=64 -Wall -W -Wdeclaration-after-state
 			-Wno-unused-function -Wno-unused-value
 
 OFLAGS	= -O2
-LDFLAGS	+= -L../library -lmbedtls $(SYS_LDFLAGS)
+LDFLAGS	+= -L../library -lmbedtls$(SHARED_SUFFIX) $(SYS_LDFLAGS)
+DLEXT=so
 
 ifndef SHARED
 DEP=../library/libmbedtls.a
 CHECK_PRELOAD=
 else
-DEP=../library/libmbedtls.so
-CHECK_PRELOAD= LD_PRELOAD=../library/libmbedtls.so
+DEP=../library/libmbedtls.$(DLEXT)
+CHECK_PRELOAD= LD_PRELOAD=../library/libmbedtls.$(DLEXT)
 endif
 
 ifdef DEBUG
 CFLAGS += -g3
 endif
 
+#
+# if we running on Windows build
+# for Windows
+#
 ifdef WINDOWS
+WINDOWS_BUILD=1
+endif
+
+ifdef WINDOWS_BUILD
+DLEXT=dll
+EXEXT=.exe
 LDFLAGS += -lws2_32
+ifdef SHARED
+SHARED_SUFFIX=.$(DLEXT)
+endif
 endif
 
 # Zlib shared library extensions:
@@ -30,44 +44,44 @@ ifdef ZLIB
 LDFLAGS += -lz
 endif
 
-APPS =	test_suite_aes.ecb		test_suite_aes.cbc		\
-		test_suite_aes.cfb		test_suite_aes.rest		\
-		test_suite_arc4			test_suite_asn1write	\
-		test_suite_base64		test_suite_blowfish		\
-		test_suite_camellia		test_suite_ccm			\
-		test_suite_cipher.aes							\
-		test_suite_cipher.arc4	test_suite_cipher.ccm	\
-		test_suite_cipher.gcm							\
-		test_suite_cipher.blowfish						\
-		test_suite_cipher.camellia						\
-		test_suite_cipher.des	test_suite_cipher.null	\
-		test_suite_cipher.padding						\
-		test_suite_ctr_drbg		test_suite_debug		\
-		test_suite_des			test_suite_dhm			\
-		test_suite_ecdh			test_suite_ecdsa		\
-		test_suite_ecp									\
-		test_suite_error		test_suite_entropy		\
-		test_suite_gcm.aes128_de						\
-		test_suite_gcm.aes192_de						\
-		test_suite_gcm.aes256_de						\
-		test_suite_gcm.aes128_en						\
-		test_suite_gcm.aes192_en						\
-		test_suite_gcm.aes256_en						\
-		test_suite_gcm.camellia	test_suite_hmac_shax	\
-		test_suite_hmac_drbg.misc						\
-		test_suite_hmac_drbg.no_reseed					\
-		test_suite_hmac_drbg.nopr						\
-		test_suite_hmac_drbg.pr							\
-		test_suite_md			test_suite_mdx			\
-		test_suite_memory_buffer_alloc					\
-		test_suite_mpi			test_suite_pbkdf2		\
-		test_suite_pem									\
-		test_suite_pkcs1_v21	test_suite_pkcs5		\
-		test_suite_pkparse		test_suite_pkwrite		\
-		test_suite_pk									\
-		test_suite_rsa			test_suite_shax			\
-		test_suite_x509parse	test_suite_x509write	\
-		test_suite_xtea			test_suite_version
+APPS =	test_suite_aes.ecb$(EXEXT)	test_suite_aes.cbc$(EXEXT)	\
+	test_suite_aes.cfb$(EXEXT)	test_suite_aes.rest$(EXEXT)	\
+	test_suite_arc4$(EXEXT)		test_suite_asn1write$(EXEXT)	\
+	test_suite_base64$(EXEXT)	test_suite_blowfish$(EXEXT)	\
+	test_suite_camellia$(EXEXT)	test_suite_ccm$(EXEXT)		\
+	test_suite_cipher.aes$(EXEXT)					\
+	test_suite_cipher.arc4$(EXEXT)	test_suite_cipher.ccm$(EXEXT)	\
+	test_suite_cipher.gcm$(EXEXT)					\
+	test_suite_cipher.blowfish$(EXEXT)				\
+	test_suite_cipher.camellia$(EXEXT)				\
+	test_suite_cipher.des$(EXEXT)	test_suite_cipher.null$(EXEXT)	\
+	test_suite_cipher.padding$(EXEXT)				\
+	test_suite_ctr_drbg$(EXEXT)	test_suite_debug$(EXEXT)	\
+	test_suite_des$(EXEXT)		test_suite_dhm$(EXEXT)		\
+	test_suite_ecdh$(EXEXT)		test_suite_ecdsa$(EXEXT)	\
+	test_suite_ecp$(EXEXT)						\
+	test_suite_error$(EXEXT)	test_suite_entropy$(EXEXT)	\
+	test_suite_gcm.aes128_de$(EXEXT)				\
+	test_suite_gcm.aes192_de$(EXEXT)				\
+	test_suite_gcm.aes256_de$(EXEXT)				\
+	test_suite_gcm.aes128_en$(EXEXT)				\
+	test_suite_gcm.aes192_en$(EXEXT)				\
+	test_suite_gcm.aes256_en$(EXEXT)				\
+	test_suite_gcm.camellia$(EXEXT)	test_suite_hmac_shax$(EXEXT)	\
+	test_suite_hmac_drbg.misc$(EXEXT)				\
+	test_suite_hmac_drbg.no_reseed$(EXEXT)				\
+	test_suite_hmac_drbg.nopr$(EXEXT)				\
+	test_suite_hmac_drbg.pr$(EXEXT)					\
+	test_suite_md$(EXEXT)		test_suite_mdx$(EXEXT)		\
+	test_suite_memory_buffer_alloc$(EXEXT)				\
+	test_suite_mpi$(EXEXT)		test_suite_pbkdf2$(EXEXT)	\
+	test_suite_pem$(EXEXT)						\
+	test_suite_pkcs1_v21$(EXEXT)	test_suite_pkcs5$(EXEXT)	\
+	test_suite_pkparse$(EXEXT)	test_suite_pkwrite$(EXEXT)	\
+	test_suite_pk$(EXEXT)						\
+	test_suite_rsa$(EXEXT)		test_suite_shax$(EXEXT)		\
+	test_suite_x509parse$(EXEXT)	test_suite_x509write$(EXEXT)	\
+	test_suite_xtea$(EXEXT)		test_suite_version$(EXEXT)
 
 .SILENT:
 
@@ -173,233 +187,233 @@ test_suite_hmac_drbg.pr.c : suites/test_suite_hmac_drbg.function suites/test_sui
 	echo   "  Generate	$@"
 	scripts/generate_code.pl suites $* $*
 
-test_suite_aes.ecb: test_suite_aes.ecb.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_aes.ecb$(EXEXT): test_suite_aes.ecb.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_aes.cbc: test_suite_aes.cbc.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_aes.cbc$(EXEXT): test_suite_aes.cbc.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_aes.cfb: test_suite_aes.cfb.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_aes.cfb$(EXEXT): test_suite_aes.cfb.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_aes.rest: test_suite_aes.rest.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_aes.rest$(EXEXT): test_suite_aes.rest.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_arc4: test_suite_arc4.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_arc4$(EXEXT): test_suite_arc4.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_asn1write: test_suite_asn1write.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_asn1write$(EXEXT): test_suite_asn1write.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_base64: test_suite_base64.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_base64$(EXEXT): test_suite_base64.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_blowfish: test_suite_blowfish.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_blowfish$(EXEXT): test_suite_blowfish.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_camellia: test_suite_camellia.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_camellia$(EXEXT): test_suite_camellia.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_ccm: test_suite_ccm.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_ccm$(EXEXT): test_suite_ccm.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_cipher.aes: test_suite_cipher.aes.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_cipher.aes$(EXEXT): test_suite_cipher.aes.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_cipher.arc4: test_suite_cipher.arc4.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_cipher.arc4$(EXEXT): test_suite_cipher.arc4.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_cipher.ccm: test_suite_cipher.ccm.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_cipher.ccm$(EXEXT): test_suite_cipher.ccm.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_cipher.gcm: test_suite_cipher.gcm.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_cipher.gcm$(EXEXT): test_suite_cipher.gcm.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_cipher.blowfish: test_suite_cipher.blowfish.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_cipher.blowfish$(EXEXT): test_suite_cipher.blowfish.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_cipher.camellia: test_suite_cipher.camellia.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_cipher.camellia$(EXEXT): test_suite_cipher.camellia.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_cipher.des: test_suite_cipher.des.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_cipher.des$(EXEXT): test_suite_cipher.des.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_cipher.null: test_suite_cipher.null.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_cipher.null$(EXEXT): test_suite_cipher.null.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_cipher.padding: test_suite_cipher.padding.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_cipher.padding$(EXEXT): test_suite_cipher.padding.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_ctr_drbg: test_suite_ctr_drbg.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_ctr_drbg$(EXEXT): test_suite_ctr_drbg.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_des: test_suite_des.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_des$(EXEXT): test_suite_des.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_dhm: test_suite_dhm.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_dhm$(EXEXT): test_suite_dhm.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_ecdh: test_suite_ecdh.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_ecdh$(EXEXT): test_suite_ecdh.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_ecdsa: test_suite_ecdsa.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_ecdsa$(EXEXT): test_suite_ecdsa.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_ecp: test_suite_ecp.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_ecp$(EXEXT): test_suite_ecp.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_entropy: test_suite_entropy.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_entropy$(EXEXT): test_suite_entropy.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_error: test_suite_error.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_error$(EXEXT): test_suite_error.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_gcm.aes128_de: test_suite_gcm.aes128_de.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_gcm.aes128_de$(EXEXT): test_suite_gcm.aes128_de.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_gcm.aes192_de: test_suite_gcm.aes192_de.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_gcm.aes192_de$(EXEXT): test_suite_gcm.aes192_de.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_gcm.aes256_de: test_suite_gcm.aes256_de.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_gcm.aes256_de$(EXEXT): test_suite_gcm.aes256_de.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_gcm.aes128_en: test_suite_gcm.aes128_en.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_gcm.aes128_en$(EXEXT): test_suite_gcm.aes128_en.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_gcm.aes192_en: test_suite_gcm.aes192_en.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_gcm.aes192_en$(EXEXT): test_suite_gcm.aes192_en.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_gcm.aes256_en: test_suite_gcm.aes256_en.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_gcm.aes256_en$(EXEXT): test_suite_gcm.aes256_en.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_gcm.camellia: test_suite_gcm.camellia.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_gcm.camellia$(EXEXT): test_suite_gcm.camellia.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_hmac_drbg.misc: test_suite_hmac_drbg.misc.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_hmac_drbg.misc$(EXEXT): test_suite_hmac_drbg.misc.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_hmac_drbg.no_reseed: test_suite_hmac_drbg.no_reseed.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_hmac_drbg.no_reseed$(EXEXT): test_suite_hmac_drbg.no_reseed.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_hmac_drbg.nopr: test_suite_hmac_drbg.nopr.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_hmac_drbg.nopr$(EXEXT): test_suite_hmac_drbg.nopr.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_hmac_drbg.pr: test_suite_hmac_drbg.pr.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_hmac_drbg.pr$(EXEXT): test_suite_hmac_drbg.pr.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_hmac_shax: test_suite_hmac_shax.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_hmac_shax$(EXEXT): test_suite_hmac_shax.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_md: test_suite_md.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_md$(EXEXT): test_suite_md.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_mdx: test_suite_mdx.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_mdx$(EXEXT): test_suite_mdx.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_memory_buffer_alloc: test_suite_memory_buffer_alloc.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_memory_buffer_alloc$(EXEXT): test_suite_memory_buffer_alloc.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_mpi: test_suite_mpi.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_mpi$(EXEXT): test_suite_mpi.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_pbkdf2: test_suite_pbkdf2.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_pbkdf2$(EXEXT): test_suite_pbkdf2.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_pem: test_suite_pem.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_pem$(EXEXT): test_suite_pem.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_pkcs1_v21: test_suite_pkcs1_v21.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_pkcs1_v21$(EXEXT): test_suite_pkcs1_v21.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_pkcs5: test_suite_pkcs5.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_pkcs5$(EXEXT): test_suite_pkcs5.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_pkparse: test_suite_pkparse.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_pkparse$(EXEXT): test_suite_pkparse.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_pkwrite: test_suite_pkwrite.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_pkwrite$(EXEXT): test_suite_pkwrite.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_pk: test_suite_pk.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_pk$(EXEXT): test_suite_pk.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_rsa: test_suite_rsa.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_rsa$(EXEXT): test_suite_rsa.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_shax: test_suite_shax.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_shax$(EXEXT): test_suite_shax.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_x509parse: test_suite_x509parse.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_x509parse$(EXEXT): test_suite_x509parse.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_x509write: test_suite_x509write.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_x509write$(EXEXT): test_suite_x509write.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_xtea: test_suite_xtea.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_xtea$(EXEXT): test_suite_xtea.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_debug: test_suite_debug.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_debug$(EXEXT): test_suite_debug.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
-test_suite_version: test_suite_version.c $(DEP)
-	echo   "  CC    	$@.c"
-	$(CC) $(CFLAGS) $(OFLAGS) $@.c	$(LDFLAGS) -o $@
+test_suite_version$(EXEXT): test_suite_version.c $(DEP)
+	echo   "  CC    	$<"
+	$(CC) $(CFLAGS) $(OFLAGS) $<	$(LDFLAGS) -o $@
 
 clean:
 ifndef WINDOWS


### PR DESCRIPTION
Add WINDOWS_BUILD macro to enable Windows build on *NIX host.

Add optional suffix for executables.

Fix shared object suffix logic to support multiple suffixes.

Fix soname handling to always match output.

WINDOWS macro sets WINDOWS_BUILD.

WINDOWS_BUILD sets .exe executable suffix.

WINDOWS_BUILD shared mode creates dll import library.

WINDOWS_BUILD shared mode link against dll.

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>