### PR TITLE
A couple memory leaks

### DIFF
--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -269,8 +269,7 @@ int asn1_get_sequence_of( unsigned char **p,
         /* Allocate and assign next pointer */
         if( *p < end )
         {
-            cur->next = polarssl_malloc(
-                 sizeof( asn1_sequence ) );
+            cur->next = polarssl_malloc( sizeof( asn1_sequence ) );
 
             if( cur->next == NULL )
                 return( POLARSSL_ERR_ASN1_MALLOC_FAILED );

--- a/library/asn1parse.c
+++ b/library/asn1parse.c
@@ -269,7 +269,7 @@ int asn1_get_sequence_of( unsigned char **p,
         /* Allocate and assign next pointer */
         if( *p < end )
         {
-            cur->next = (asn1_sequence *) polarssl_malloc(
+            cur->next = polarssl_malloc(
                  sizeof( asn1_sequence ) );
 
             if( cur->next == NULL )

--- a/library/bignum.c
+++ b/library/bignum.c
@@ -107,7 +107,7 @@ int mpi_grow( mpi *X, size_t nblimbs )
 
     if( X->n < nblimbs )
     {
-        if( ( p = (t_uint *) polarssl_malloc( nblimbs * ciL ) ) == NULL )
+        if( ( p = polarssl_malloc( nblimbs * ciL ) ) == NULL )
             return( POLARSSL_ERR_MPI_MALLOC_FAILED );
 
         memset( p, 0, nblimbs * ciL );
@@ -147,7 +147,7 @@ int mpi_shrink( mpi *X, size_t nblimbs )
     if( i < nblimbs )
         i = nblimbs;
 
-    if( ( p = (t_uint *) polarssl_malloc( i * ciL ) ) == NULL )
+    if( ( p = polarssl_malloc( i * ciL ) ) == NULL )
         return( POLARSSL_ERR_MPI_MALLOC_FAILED );
 
     memset( p, 0, i * ciL );

--- a/library/cipher_wrap.c
+++ b/library/cipher_wrap.c
@@ -179,7 +179,7 @@ static int aes_setkey_enc_wrap( void *ctx, const unsigned char *key,
 
 static void * aes_ctx_alloc( void )
 {
-    aes_context *aes = (aes_context *) polarssl_malloc( sizeof( aes_context ) );
+    aes_context *aes = polarssl_malloc( sizeof( aes_context ) );
 
     if( aes == NULL )
         return( NULL );
@@ -541,7 +541,7 @@ static int camellia_setkey_enc_wrap( void *ctx, const unsigned char *key,
 static void * camellia_ctx_alloc( void )
 {
     camellia_context *ctx;
-    ctx = (camellia_context *) polarssl_malloc( sizeof( camellia_context ) );
+    ctx = polarssl_malloc( sizeof( camellia_context ) );
 
     if( ctx == NULL )
         return( NULL );
@@ -922,7 +922,7 @@ static int des3_set3key_enc_wrap( void *ctx, const unsigned char *key,
 
 static void * des_ctx_alloc( void )
 {
-    des_context *des = (des_context *) polarssl_malloc( sizeof( des_context ) );
+    des_context *des = polarssl_malloc( sizeof( des_context ) );
 
     if( des == NULL )
         return( NULL );
@@ -941,7 +941,7 @@ static void des_ctx_free( void *ctx )
 static void * des3_ctx_alloc( void )
 {
     des3_context *des3;
-    des3 = (des3_context *) polarssl_malloc( sizeof( des3_context ) );
+    des3 = polarssl_malloc( sizeof( des3_context ) );
 
     if( des3 == NULL )
         return( NULL );
@@ -1145,7 +1145,7 @@ static int blowfish_setkey_wrap( void *ctx, const unsigned char *key,
 static void * blowfish_ctx_alloc( void )
 {
     blowfish_context *ctx;
-    ctx = (blowfish_context *) polarssl_malloc( sizeof( blowfish_context ) );
+    ctx = polarssl_malloc( sizeof( blowfish_context ) );
 
     if( ctx == NULL )
         return( NULL );
@@ -1247,7 +1247,7 @@ static int arc4_setkey_wrap( void *ctx, const unsigned char *key,
 static void * arc4_ctx_alloc( void )
 {
     arc4_context *ctx;
-    ctx = (arc4_context *) polarssl_malloc( sizeof( arc4_context ) );
+    ctx = polarssl_malloc( sizeof( arc4_context ) );
 
     if( ctx == NULL )
         return( NULL );

--- a/library/dhm.c
+++ b/library/dhm.c
@@ -505,7 +505,7 @@ static int load_file( const char *path, unsigned char **buf, size_t *n )
     *n = (size_t) size;
 
     if( *n + 1 == 0 ||
-        ( *buf = (unsigned char *) polarssl_malloc( *n + 1 ) ) == NULL )
+        ( *buf = polarssl_malloc( *n + 1 ) ) == NULL )
     {
         fclose( f );
         return( POLARSSL_ERR_DHM_MALLOC_FAILED );

--- a/library/ecp.c
+++ b/library/ecp.c
@@ -812,7 +812,7 @@ static int ecp_normalize_jac_many( const ecp_group *grp,
     if( t_len < 2 )
         return( ecp_normalize_jac( grp, *T ) );
 
-    if( ( c = (mpi *) polarssl_malloc( t_len * sizeof( mpi ) ) ) == NULL )
+    if( ( c = polarssl_malloc( t_len * sizeof( mpi ) ) ) == NULL )
         return( POLARSSL_ERR_ECP_MALLOC_FAILED );
 
     mpi_init( &u ); mpi_init( &Zi ); mpi_init( &ZZi );
@@ -1415,7 +1415,7 @@ static int ecp_mul_comb( ecp_group *grp, ecp_point *R,
 
     if( T == NULL )
     {
-        T = (ecp_point *) polarssl_malloc( pre_len * sizeof( ecp_point ) );
+        T = polarssl_malloc( pre_len * sizeof( ecp_point ) );
         if( T == NULL )
         {
             ret = POLARSSL_ERR_ECP_MALLOC_FAILED;

--- a/library/md_wrap.c
+++ b/library/md_wrap.c
@@ -396,7 +396,7 @@ static void ripemd160_hmac_reset_wrap( void *ctx )
 static void * ripemd160_ctx_alloc( void )
 {
     ripemd160_context *ctx;
-    ctx = (ripemd160_context *) polarssl_malloc( sizeof( ripemd160_context ) );
+    ctx = polarssl_malloc( sizeof( ripemd160_context ) );
 
     if( ctx == NULL )
         return( NULL );
@@ -492,7 +492,7 @@ static void sha1_hmac_reset_wrap( void *ctx )
 static void * sha1_ctx_alloc( void )
 {
     sha1_context *ctx;
-    ctx = (sha1_context *) polarssl_malloc( sizeof( sha1_context ) );
+    ctx = polarssl_malloc( sizeof( sha1_context ) );
 
     if( ctx == NULL )
         return( NULL );
@@ -701,7 +701,7 @@ static void sha256_hmac_wrap( const unsigned char *key, size_t keylen,
 static void * sha256_ctx_alloc( void )
 {
     sha256_context *ctx;
-    ctx = (sha256_context *) polarssl_malloc( sizeof( sha256_context ) );
+    ctx = polarssl_malloc( sizeof( sha256_context ) );
 
     if( ctx == NULL )
         return( NULL );
@@ -907,7 +907,7 @@ static void sha512_hmac_wrap( const unsigned char *key, size_t keylen,
 static void * sha512_ctx_alloc( void )
 {
     sha512_context *ctx;
-    ctx = (sha512_context *) polarssl_malloc( sizeof( sha512_context ) );
+    ctx = polarssl_malloc( sizeof( sha512_context ) );
 
     if( ctx == NULL )
         return( NULL );

--- a/library/pem.c
+++ b/library/pem.c
@@ -319,7 +319,7 @@ int pem_read_buffer( pem_context *ctx, const char *header, const char *footer,
     if( ret == POLARSSL_ERR_BASE64_INVALID_CHARACTER )
         return( POLARSSL_ERR_PEM_INVALID_DATA + ret );
 
-    if( ( buf = (unsigned char *) polarssl_malloc( len ) ) == NULL )
+    if( ( buf = polarssl_malloc( len ) ) == NULL )
         return( POLARSSL_ERR_PEM_MALLOC_FAILED );
 
     if( ( ret = base64_decode( buf, &len, s1, s2 - s1 ) ) != 0 )

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -87,7 +87,7 @@ int pk_load_file( const char *path, unsigned char **buf, size_t *n )
     *n = (size_t) size;
 
     if( *n + 1 == 0 ||
-        ( *buf = (unsigned char *) polarssl_malloc( *n + 1 ) ) == NULL )
+        ( *buf = polarssl_malloc( *n + 1 ) ) == NULL )
     {
         fclose( f );
         return( POLARSSL_ERR_PK_MALLOC_FAILED );

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -258,8 +258,7 @@ int ssl_cache_set( void *data, const ssl_session *session )
      */
     if( session->peer_cert != NULL )
     {
-        cur->peer_cert.p = polarssl_malloc(
-                            session->peer_cert->raw.len );
+        cur->peer_cert.p = polarssl_malloc( session->peer_cert->raw.len );
         if( cur->peer_cert.p == NULL )
         {
             ret = 1;

--- a/library/ssl_cache.c
+++ b/library/ssl_cache.c
@@ -102,7 +102,7 @@ int ssl_cache_get( void *data, ssl_session *session )
          */
         if( entry->peer_cert.p != NULL )
         {
-            if( ( session->peer_cert = (x509_crt *) polarssl_malloc(
+            if( ( session->peer_cert = polarssl_malloc(
                                  sizeof(x509_crt) ) ) == NULL )
             {
                 ret = 1;
@@ -221,7 +221,7 @@ int ssl_cache_set( void *data, const ssl_session *session )
             /*
              * max_entries not reached, create new entry
              */
-            cur = (ssl_cache_entry *) polarssl_malloc( sizeof(ssl_cache_entry) );
+            cur = polarssl_malloc( sizeof(ssl_cache_entry) );
             if( cur == NULL )
             {
                 ret = 1;
@@ -258,7 +258,7 @@ int ssl_cache_set( void *data, const ssl_session *session )
      */
     if( session->peer_cert != NULL )
     {
-        cur->peer_cert.p = (unsigned char *) polarssl_malloc(
+        cur->peer_cert.p = polarssl_malloc(
                             session->peer_cert->raw.len );
         if( cur->peer_cert.p == NULL )
         {

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -3544,20 +3544,17 @@ static int ssl_handshake_init( ssl_context *ssl )
      */
     if( ssl->transform_negotiate == NULL )
     {
-        ssl->transform_negotiate = polarssl_malloc(
-                             sizeof(ssl_transform) );
+        ssl->transform_negotiate = polarssl_malloc( sizeof(ssl_transform) );
     }
 
     if( ssl->session_negotiate == NULL )
     {
-        ssl->session_negotiate = polarssl_malloc(
-                           sizeof(ssl_session) );
+        ssl->session_negotiate = polarssl_malloc( sizeof(ssl_session) );
     }
 
     if( ssl->handshake == NULL )
     {
-        ssl->handshake =
-            polarssl_malloc( sizeof(ssl_handshake_params) );
+        ssl->handshake = polarssl_malloc( sizeof(ssl_handshake_params) );
     }
 
     /* All pointers should exist and can be directly freed without issue */
@@ -4064,8 +4061,7 @@ int ssl_set_psk( ssl_context *ssl, const unsigned char *psk, size_t psk_len,
     ssl->psk_identity_len = psk_identity_len;
 
     ssl->psk = polarssl_malloc( ssl->psk_len );
-    ssl->psk_identity =
-                                polarssl_malloc( ssl->psk_identity_len );
+    ssl->psk_identity = polarssl_malloc( ssl->psk_identity_len );
 
     if( ssl->psk == NULL || ssl->psk_identity == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -92,7 +92,7 @@ static int ssl_session_copy( ssl_session *dst, const ssl_session *src )
     {
         int ret;
 
-        dst->peer_cert = (x509_crt *) polarssl_malloc( sizeof(x509_crt) );
+        dst->peer_cert = polarssl_malloc( sizeof(x509_crt) );
         if( dst->peer_cert == NULL )
             return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
@@ -111,7 +111,7 @@ static int ssl_session_copy( ssl_session *dst, const ssl_session *src )
 #if defined(POLARSSL_SSL_SESSION_TICKETS)
     if( src->ticket != NULL )
     {
-        dst->ticket = (unsigned char *) polarssl_malloc( src->ticket_len );
+        dst->ticket = polarssl_malloc( src->ticket_len );
         if( dst->ticket == NULL )
             return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
@@ -2747,7 +2747,7 @@ int ssl_parse_certificate( ssl_context *ssl )
         polarssl_free( ssl->session_negotiate->peer_cert );
     }
 
-    if( ( ssl->session_negotiate->peer_cert = (x509_crt *) polarssl_malloc(
+    if( ( ssl->session_negotiate->peer_cert = polarssl_malloc(
                     sizeof( x509_crt ) ) ) == NULL )
     {
         SSL_DEBUG_MSG( 1, ( "malloc(%d bytes) failed",
@@ -3544,19 +3544,19 @@ static int ssl_handshake_init( ssl_context *ssl )
      */
     if( ssl->transform_negotiate == NULL )
     {
-        ssl->transform_negotiate = (ssl_transform *) polarssl_malloc(
+        ssl->transform_negotiate = polarssl_malloc(
                              sizeof(ssl_transform) );
     }
 
     if( ssl->session_negotiate == NULL )
     {
-        ssl->session_negotiate = (ssl_session *) polarssl_malloc(
+        ssl->session_negotiate = polarssl_malloc(
                            sizeof(ssl_session) );
     }
 
     if( ssl->handshake == NULL )
     {
-        ssl->handshake = (ssl_handshake_params *)
+        ssl->handshake =
             polarssl_malloc( sizeof(ssl_handshake_params) );
     }
 
@@ -3630,7 +3630,7 @@ int ssl_init( ssl_context *ssl )
     /*
      * Prepare base structures
      */
-    ssl->in_ctr = (unsigned char *) polarssl_malloc( len );
+    ssl->in_ctr = polarssl_malloc( len );
     ssl->in_hdr = ssl->in_ctr +  8;
     ssl->in_iv  = ssl->in_ctr + 13;
     ssl->in_msg = ssl->in_ctr + 13;
@@ -3641,7 +3641,7 @@ int ssl_init( ssl_context *ssl )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
     }
 
-    ssl->out_ctr = (unsigned char *) polarssl_malloc( len );
+    ssl->out_ctr = polarssl_malloc( len );
     ssl->out_hdr = ssl->out_ctr +  8;
     ssl->out_iv  = ssl->out_ctr + 13;
     ssl->out_msg = ssl->out_ctr + 13;
@@ -3782,7 +3782,7 @@ static int ssl_ticket_keys_init( ssl_context *ssl )
     if( ssl->ticket_keys != NULL )
         return( 0 );
 
-    tkeys = (ssl_ticket_keys *) polarssl_malloc( sizeof(ssl_ticket_keys) );
+    tkeys = polarssl_malloc( sizeof(ssl_ticket_keys) );
     if( tkeys == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
@@ -3939,7 +3939,7 @@ static ssl_key_cert *ssl_add_key_cert( ssl_context *ssl )
 {
     ssl_key_cert *key_cert, *last;
 
-    key_cert = (ssl_key_cert *) polarssl_malloc( sizeof(ssl_key_cert) );
+    key_cert = polarssl_malloc( sizeof(ssl_key_cert) );
     if( key_cert == NULL )
         return( NULL );
 
@@ -3995,7 +3995,7 @@ int ssl_set_own_cert_rsa( ssl_context *ssl, x509_crt *own_cert,
     if( key_cert == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
-    key_cert->key = (pk_context *) polarssl_malloc( sizeof(pk_context) );
+    key_cert->key = polarssl_malloc( sizeof(pk_context) );
     if( key_cert->key == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
@@ -4027,7 +4027,7 @@ int ssl_set_own_cert_alt( ssl_context *ssl, x509_crt *own_cert,
     if( key_cert == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
-    key_cert->key = (pk_context *) polarssl_malloc( sizeof(pk_context) );
+    key_cert->key = polarssl_malloc( sizeof(pk_context) );
     if( key_cert->key == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
 
@@ -4063,8 +4063,8 @@ int ssl_set_psk( ssl_context *ssl, const unsigned char *psk, size_t psk_len,
     ssl->psk_len = psk_len;
     ssl->psk_identity_len = psk_identity_len;
 
-    ssl->psk = (unsigned char *) polarssl_malloc( ssl->psk_len );
-    ssl->psk_identity = (unsigned char *)
+    ssl->psk = polarssl_malloc( ssl->psk_len );
+    ssl->psk_identity =
                                 polarssl_malloc( ssl->psk_identity_len );
 
     if( ssl->psk == NULL || ssl->psk_identity == NULL )
@@ -4147,7 +4147,7 @@ int ssl_set_hostname( ssl_context *ssl, const char *hostname )
     if( ssl->hostname_len + 1 == 0 )
         return( POLARSSL_ERR_SSL_BAD_INPUT_DATA );
 
-    ssl->hostname = (unsigned char *) polarssl_malloc( ssl->hostname_len + 1 );
+    ssl->hostname = polarssl_malloc( ssl->hostname_len + 1 );
 
     if( ssl->hostname == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );

--- a/library/ssl_tls.c
+++ b/library/ssl_tls.c
@@ -4063,8 +4063,13 @@ int ssl_set_psk( ssl_context *ssl, const unsigned char *psk, size_t psk_len,
     ssl->psk = polarssl_malloc( ssl->psk_len );
     ssl->psk_identity = polarssl_malloc( ssl->psk_identity_len );
 
-    if( ssl->psk == NULL || ssl->psk_identity == NULL )
+    if( ssl->psk == NULL )
         return( POLARSSL_ERR_SSL_MALLOC_FAILED );
+    if( ssl->psk_identity == NULL )
+    {
+        polarssl_free( ssl->psk );
+        return( POLARSSL_ERR_SSL_MALLOC_FAILED );
+    }
 
     memcpy( ssl->psk, psk, ssl->psk_len );
     memcpy( ssl->psk_identity, psk_identity, ssl->psk_identity_len );

--- a/library/x509.c
+++ b/library/x509.c
@@ -445,7 +445,7 @@ int x509_get_name( unsigned char **p, const unsigned char *end,
             /* Mark this item as being only one in a set */
             cur->next_merged = 1;
 
-            cur->next = (x509_name *) polarssl_malloc( sizeof( x509_name ) );
+            cur->next = polarssl_malloc( sizeof( x509_name ) );
 
             if( cur->next == NULL )
                 return( POLARSSL_ERR_X509_MALLOC_FAILED );
@@ -461,7 +461,7 @@ int x509_get_name( unsigned char **p, const unsigned char *end,
         if( *p == end )
             return( 0 );
 
-        cur->next = (x509_name *) polarssl_malloc( sizeof( x509_name ) );
+        cur->next = polarssl_malloc( sizeof( x509_name ) );
 
         if( cur->next == NULL )
             return( POLARSSL_ERR_X509_MALLOC_FAILED );

--- a/library/x509_crl.c
+++ b/library/x509_crl.c
@@ -277,7 +277,7 @@ int x509_crl_parse_der( x509_crl *chain,
 
     if( crl->version != 0 && crl->next == NULL )
     {
-        crl->next = (x509_crl *) polarssl_malloc( sizeof( x509_crl ) );
+        crl->next = polarssl_malloc( sizeof( x509_crl ) );
 
         if( crl->next == NULL )
         {

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -356,8 +356,7 @@ static int x509_get_subject_alt_name( unsigned char **p,
             if( cur->next != NULL )
                 return( POLARSSL_ERR_X509_INVALID_EXTENSIONS );
 
-            cur->next = polarssl_malloc(
-                 sizeof( asn1_sequence ) );
+            cur->next = polarssl_malloc( sizeof( asn1_sequence ) );
 
             if( cur->next == NULL )
                 return( POLARSSL_ERR_X509_INVALID_EXTENSIONS +

--- a/library/x509_crt.c
+++ b/library/x509_crt.c
@@ -356,7 +356,7 @@ static int x509_get_subject_alt_name( unsigned char **p,
             if( cur->next != NULL )
                 return( POLARSSL_ERR_X509_INVALID_EXTENSIONS );
 
-            cur->next = (asn1_sequence *) polarssl_malloc(
+            cur->next = polarssl_malloc(
                  sizeof( asn1_sequence ) );
 
             if( cur->next == NULL )
@@ -550,7 +550,7 @@ static int x509_crt_parse_der_core( x509_crt *crt, const unsigned char *buf,
     if( crt == NULL || buf == NULL )
         return( POLARSSL_ERR_X509_BAD_INPUT_DATA );
 
-    p = (unsigned char *) polarssl_malloc( len = buflen );
+    p = polarssl_malloc( len = buflen );
 
     if( p == NULL )
         return( POLARSSL_ERR_X509_MALLOC_FAILED );
@@ -807,7 +807,7 @@ int x509_crt_parse_der( x509_crt *chain, const unsigned char *buf,
      */
     if( crt->version != 0 && crt->next == NULL )
     {
-        crt->next = (x509_crt *) polarssl_malloc( sizeof( x509_crt ) );
+        crt->next = polarssl_malloc( sizeof( x509_crt ) );
 
         if( crt->next == NULL )
             return( POLARSSL_ERR_X509_MALLOC_FAILED );

--- a/library/x509_csr.c
+++ b/library/x509_csr.c
@@ -110,7 +110,7 @@ int x509_csr_parse_der( x509_csr *csr,
     /*
      * first copy the raw DER data
      */
-    p = (unsigned char *) polarssl_malloc( len = buflen );
+    p = polarssl_malloc( len = buflen );
 
     if( p == NULL )
         return( POLARSSL_ERR_X509_MALLOC_FAILED );

--- a/programs/ssl/ssl_server2.c
+++ b/programs/ssl/ssl_server2.c
@@ -419,13 +419,13 @@ sni_entry *sni_parse( char *sni_string )
     while( p <= end )
     {
         if( ( new = polarssl_malloc( sizeof( sni_entry ) ) ) == NULL )
-            return( NULL );
+            goto error;
 
         memset( new, 0, sizeof( sni_entry ) );
 
         if( ( new->cert = polarssl_malloc( sizeof( x509_crt ) ) ) == NULL ||
             ( new->key = polarssl_malloc( sizeof( pk_context ) ) ) == NULL )
-            return( NULL );
+            goto error;
 
         x509_crt_init( new->cert );
         pk_init( new->key );
@@ -436,13 +436,17 @@ sni_entry *sni_parse( char *sni_string )
 
         if( x509_crt_parse_file( new->cert, crt_file ) != 0 ||
             pk_parse_keyfile( new->key, key_file, "" ) != 0 )
-            return( NULL );
+            goto error;
 
         new->next = cur;
         cur = new;
     }
 
     return( cur );
+
+error:
+    sni_free( new );
+    return( NULL );
 }
 
 void sni_free( sni_entry *head )

--- a/programs/test/ssl_test.c
+++ b/programs/test/ssl_test.c
@@ -295,8 +295,8 @@ static int ssl_test( struct options *opt )
         }
     }
 
-     read_buf = (unsigned char *) polarssl_malloc( opt->buffer_size );
-    write_buf = (unsigned char *) polarssl_malloc( opt->buffer_size );
+     read_buf = polarssl_malloc( opt->buffer_size );
+    write_buf = polarssl_malloc( opt->buffer_size );
 
     if( read_buf == NULL || write_buf == NULL )
     {

--- a/programs/util/pem2der.c
+++ b/programs/util/pem2der.c
@@ -129,7 +129,7 @@ static int load_file( const char *path, unsigned char **buf, size_t *n )
     *n = (size_t) size;
 
     if( *n + 1 == 0 ||
-        ( *buf = (unsigned char *) polarssl_malloc( *n + 1 ) ) == NULL )
+        ( *buf = polarssl_malloc( *n + 1 ) ) == NULL )
     {
         fclose( f );
         return( -1 );

--- a/scripts/find-mem-leak.cocci
+++ b/scripts/find-mem-leak.cocci
@@ -1,0 +1,9 @@
+@@
+expression x, y;
+statement S;
+@@
+  x = polarssl_malloc(...);
+  y = polarssl_malloc(...);
+  ...
+* if (x == NULL || y == NULL)
+    S

--- a/scripts/find-mem-leak.cocci
+++ b/scripts/find-mem-leak.cocci
@@ -7,3 +7,14 @@ statement S;
   ...
 * if (x == NULL || y == NULL)
     S
+
+@@
+expression x, y;
+statement S;
+@@
+  if (
+*   (x = polarssl_malloc(...)) == NULL
+    ||
+*   (y = polarssl_malloc(...)) == NULL
+  )
+    S

--- a/scripts/rm-malloc-cast.cocci
+++ b/scripts/rm-malloc-cast.cocci
@@ -1,0 +1,7 @@
+@rm_malloc_cast@
+expression x, n;
+type T;
+@@
+  x =
+- (T *)
+  polarssl_malloc(n)


### PR DESCRIPTION
In a couple places memory wasn't freed before the function returned.

The first case in `library/ssl_tls.c` was simple. In the second case, in `programs/ssl/ssl_server2.c`, I jump to an "error" block and use `sni_free` -- is `sni_free` correct here?

The script also detects a false positive in `programs/test/ssl_test.c`.